### PR TITLE
Scaffold Dart MCP server with echo tool

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,11 @@
 {
   "name": "flutter-agent-tools",
   "version": "0.1.0",
-  "description": "Flutter/Dart agent tooling: dependency health, API inspection, and UI runtime introspection."
+  "description": "Flutter/Dart agent tooling: dependency health, API inspection, and UI runtime introspection.",
+  "mcpServers": {
+    "flutter-agent": {
+      "command": "dart",
+      "args": ["run", "flutter_agent_tools:mcp_server"]
+    }
+  }
 }

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/bin/mcp_server.dart
+++ b/bin/mcp_server.dart
@@ -1,0 +1,8 @@
+import 'dart:io' as io;
+
+import 'package:dart_mcp/stdio.dart';
+import 'package:flutter_agent_tools/mcp_server.dart';
+
+void main() {
+  FlutterAgentServer(stdioChannel(input: io.stdin, output: io.stdout));
+}

--- a/lib/mcp_server.dart
+++ b/lib/mcp_server.dart
@@ -1,0 +1,1 @@
+export 'src/mcp_server.dart';

--- a/lib/src/mcp_server.dart
+++ b/lib/src/mcp_server.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:dart_mcp/server.dart';
+
+/// The MCP server for flutter-agent-tools.
+base class FlutterAgentServer extends MCPServer with ToolsSupport {
+  FlutterAgentServer(super.channel)
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'flutter-agent-tools',
+          version: '0.1.0',
+        ),
+        instructions:
+            'Tools for AI agents working on Dart and Flutter projects.',
+      ) {
+    registerTool(echoTool, _echo);
+  }
+
+  final echoTool = Tool(
+    name: 'echo',
+    description: 'Returns the provided text unchanged.',
+    inputSchema: Schema.object(
+      properties: {
+        'text': Schema.string(description: 'The text to echo back.'),
+      },
+      required: ['text'],
+    ),
+  );
+
+  FutureOr<CallToolResult> _echo(CallToolRequest request) {
+    final text = request.arguments!['text'] as String;
+    return CallToolResult(content: [TextContent(text: text)]);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,13 @@
+name: flutter_agent_tools
+description: A Claude Code plugin that makes AI coding agents more effective when working on Dart and Flutter projects.
+version: 0.1.0
+repository: https://github.com/devoncarew/flutter-agent-tools
+
+environment:
+  sdk: ^3.7.0
+
+dependencies:
+  dart_mcp: ^0.5.0
+
+dev_dependencies:
+  lints: ^5.0.0


### PR DESCRIPTION
Adds the initial Dart package and MCP server scaffold.

- `pubspec.yaml` at root: package `flutter_agent_tools`, depends on `dart_mcp ^0.5.0`
- `bin/mcp_server.dart`: entry point, connects `FlutterAgentServer` to stdio
- `lib/src/mcp_server.dart`: `FlutterAgentServer` with a single `echo` tool (returns input text unchanged)
- `analysis_options.yaml`: recommended lints
- `plugin.json`: declares the MCP server so Claude Code loads it automatically

The echo tool serves as the hello-world scaffold; real tools (Package API Inspector, Flutter UI Agent) will replace it.