### PR TITLE
Add flutter_launch_app and flutter_close_app MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ MCP commands for building, launching, and introspecting a running Flutter app at
 runtime: query semantic elements, inject text, trigger taps, and pull unhandled
 exceptions from the Dart VM Service.
 
+<!-- flutter commands -->
+| Command | Description |
+|---------|-------------|
+| `echo` | Returns the provided text unchanged. |
+| `flutter_launch_app` | Builds and launches the Flutter app, returning a session ID for use with subsequent flutter_* tools. |
+| `flutter_close_app` | Stops a running Flutter app and releases its session. |
+<!-- flutter commands -->
+
 ## Installation
 
 ```sh

--- a/lib/src/mcp_server.dart
+++ b/lib/src/mcp_server.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:dart_mcp/server.dart';
 import 'package:flutter_daemon/flutter_daemon.dart';
+import 'package:unique_names_generator/unique_names_generator.dart';
 
 /// The MCP server for flutter-agent-tools.
 base class FlutterAgentServer extends MCPServer with ToolsSupport {
@@ -17,17 +18,46 @@ base class FlutterAgentServer extends MCPServer with ToolsSupport {
       ) {
     registerTool(echoTool, _echo);
     registerTool(flutterLaunchAppTool, _flutterLaunchApp);
+    registerTool(flutterCloseAppTool, _flutterCloseApp);
   }
 
-  final _sessions = <String, FlutterApplication>{};
-  final _random = Random();
+  FlutterDaemon? _daemon;
+  FlutterDaemon get _daemonInstance => _daemon ??= FlutterDaemon();
 
-  String _newSessionId() => List.generate(
-    8,
-    (_) => _random.nextInt(256).toRadixString(16).padLeft(2, '0'),
-  ).join();
+  final Map<String, FlutterApplication> _sessions = {};
 
-  final echoTool = Tool(
+  @override
+  Future<void> shutdown() async {
+    await Future.wait(_sessions.values.map((app) => app.stop()));
+    _sessions.clear();
+    await _daemon?.dispose();
+    await super.shutdown();
+  }
+
+  final Random _random = Random();
+  final UniqueNamesGenerator _nameGenerator = UniqueNamesGenerator(
+    config: Config(
+      length: 2,
+      dictionaries: [adjectives, animals],
+      separator: '-',
+    ),
+  );
+
+  String _newSessionId() {
+    final suffix =
+        List.generate(
+          2,
+          (_) => _random
+              .nextInt(256)
+              .toRadixString(16)
+              .toUpperCase()
+              .padLeft(2, '0'),
+        ).join();
+
+    return [_nameGenerator.generate(), suffix].join('-');
+  }
+
+  final Tool echoTool = Tool(
     name: 'echo',
     description: 'Returns the provided text unchanged.',
     inputSchema: Schema.object(
@@ -43,7 +73,7 @@ base class FlutterAgentServer extends MCPServer with ToolsSupport {
     return CallToolResult(content: [TextContent(text: text)]);
   }
 
-  final flutterLaunchAppTool = Tool(
+  final Tool flutterLaunchAppTool = Tool(
     name: 'flutter_launch_app',
     description:
         'Builds and launches the Flutter app, returning a session ID for use '
@@ -78,8 +108,7 @@ base class FlutterAgentServer extends MCPServer with ToolsSupport {
       if (target != null) ...['--target', target],
     ];
 
-    final daemon = FlutterDaemon();
-    final application = await daemon.run(
+    final application = await _daemonInstance.run(
       arguments: arguments,
       workingDirectory: workingDirectory,
     );
@@ -90,5 +119,33 @@ base class FlutterAgentServer extends MCPServer with ToolsSupport {
     return CallToolResult(
       content: [TextContent(text: 'Launched. Session ID: $sessionId')],
     );
+  }
+
+  final Tool flutterCloseAppTool = Tool(
+    name: 'flutter_close_app',
+    description: 'Stops a running Flutter app and releases its session.',
+    inputSchema: Schema.object(
+      properties: {
+        'session_id': Schema.string(
+          description: 'The session ID returned by flutter_launch_app.',
+        ),
+      },
+      required: ['session_id'],
+    ),
+  );
+
+  Future<CallToolResult> _flutterCloseApp(CallToolRequest request) async {
+    final sessionId = request.arguments!['session_id'] as String;
+    final application = _sessions.remove(sessionId);
+
+    if (application == null) {
+      return CallToolResult(
+        isError: true,
+        content: [TextContent(text: 'No session found for ID: $sessionId')],
+      );
+    }
+
+    await application.stop();
+    return CallToolResult(content: [TextContent(text: 'App stopped.')]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
 dependencies:
   dart_mcp: ^0.5.0
   flutter_daemon: ^1.0.1
+  unique_names_generator: ^3.1.2
 
 dev_dependencies:
   lints: ^6.0.0

--- a/tool/generate_readme.dart
+++ b/tool/generate_readme.dart
@@ -1,0 +1,80 @@
+// Generates the MCP commands table in README.md.
+//
+// Run with: dart run tool/generate_readme.dart
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_mcp/client.dart';
+import 'package:flutter_agent_tools/mcp_server.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+const _marker = '<!-- flutter commands -->';
+
+void main() async {
+  // Wire up an in-process client/server pair.
+  final clientController = StreamController<String>();
+  final serverController = StreamController<String>();
+
+  final clientChannel = StreamChannel<String>.withCloseGuarantee(
+    serverController.stream,
+    clientController.sink,
+  );
+  final serverChannel = StreamChannel<String>.withCloseGuarantee(
+    clientController.stream,
+    serverController.sink,
+  );
+
+  final server = FlutterAgentServer(serverChannel);
+  final client = _ScriptClient();
+  final connection = client.connectServer(clientChannel);
+
+  await connection.initialize(
+    InitializeRequest(
+      protocolVersion: ProtocolVersion.latestSupported,
+      capabilities: client.capabilities,
+      clientInfo: client.implementation,
+    ),
+  );
+  connection.notifyInitialized(InitializedNotification());
+  await server.initialized;
+
+  final toolsResult = await connection.listTools(ListToolsRequest());
+
+  await client.shutdown();
+  await server.shutdown();
+
+  // Build the markdown table.
+  final buf = StringBuffer();
+  buf.writeln('| Command | Description |');
+  buf.writeln('|---------|-------------|');
+  for (final tool in toolsResult.tools) {
+    buf.write('| `${tool.name}` | ${tool.description} |');
+    buf.writeln();
+  }
+
+  // Splice the table into README.md between the two markers.
+  final readme = File('README.md');
+  final original = readme.readAsStringSync();
+
+  final start = original.indexOf(_marker);
+  final end = original.indexOf(_marker, start + _marker.length);
+
+  if (start == -1 || end == -1) {
+    stderr.writeln('Could not find $_marker markers in README.md');
+    exitCode = 1;
+    return;
+  }
+
+  final updated =
+      '${original.substring(0, start + _marker.length)}\n'
+      '${buf.toString()}'
+      '${original.substring(end)}';
+
+  readme.writeAsStringSync(updated);
+  print('README.md updated.');
+}
+
+base class _ScriptClient extends MCPClient {
+  _ScriptClient() : super(Implementation(name: 'readme-gen', version: '0.1.0'));
+}


### PR DESCRIPTION
Implements the first Flutter UI Agent tools and adds README generation tooling.

- `flutter_launch_app`: launches a Flutter app via `flutter_daemon`, returning a named session ID
- `flutter_close_app`: stops a running app by session ID; all sessions are stopped on server shutdown
- Single shared `FlutterDaemon` instance, lazily initialized
- Session IDs generated with `unique_names_generator` (adjective-animal-hex suffix)
- `tool/generate_readme.dart`: connects to the server in-process via the MCP protocol to list tools, then splices the result as a Markdown table into README.md between `<!-- flutter commands -->` markers