### PR TITLE
Replace flutter_daemon with custom flutter run --machine client

### DIFF
--- a/lib/src/flutter_run.dart
+++ b/lib/src/flutter_run.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// An event emitted by a running Flutter app via the `flutter run --machine`
+/// daemon protocol.
+class FlutterEvent {
+  FlutterEvent(this.event, this.params);
+
+  final String event;
+  final Map<String, dynamic> params;
+}
+
+/// Manages a `flutter run --machine` subprocess.
+///
+/// Use [FlutterRunSession.start] to launch a Flutter app and obtain a session.
+/// The session provides [events] for monitoring app lifecycle and output,
+/// [restart] for hot reload/restart, and [stop] to terminate the app.
+class FlutterRunSession {
+  FlutterRunSession._(this._process) {
+    _process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(_handleLine, onDone: _handleDone);
+    _process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(_stderrLines.add);
+  }
+
+  final Process _process;
+  String? _appId;
+
+  final Completer<void> _startedCompleter = Completer<void>();
+  final StreamController<FlutterEvent> _eventController =
+      StreamController<FlutterEvent>.broadcast();
+  final List<String> _stderrLines = [];
+  int _nextId = 0;
+  final Map<int, Completer<Map<String, dynamic>>> _pending = {};
+
+  /// Events emitted by the running Flutter app.
+  Stream<FlutterEvent> get events => _eventController.stream;
+
+  /// Launches `flutter run --machine` in [workingDirectory] and waits until
+  /// the app has fully started.
+  ///
+  /// Throws a [StateError] if the process exits before the app starts.
+  static Future<FlutterRunSession> start({
+    required String workingDirectory,
+    String? deviceId,
+    String? target,
+  }) async {
+    final List<String> args = [
+      'run',
+      '--machine',
+      if (deviceId != null) ...['--device-id', deviceId],
+      if (target != null) ...['--target', target],
+    ];
+
+    final Process process = await Process.start(
+      'flutter',
+      args,
+      workingDirectory: workingDirectory,
+    );
+
+    final FlutterRunSession session = FlutterRunSession._(process);
+    await session._startedCompleter.future;
+    return session;
+  }
+
+  /// Hot reloads the app. If [fullRestart] is true, performs a hot restart
+  /// instead.
+  Future<void> restart({bool fullRestart = false}) async {
+    final String appId = _appId!;
+    final Map<String, dynamic> result = await _sendCommand('app.restart', {
+      'appId': appId,
+      'fullRestart': fullRestart,
+    });
+    final int code = (result['code'] as num?)?.toInt() ?? 0;
+    if (code != 0) {
+      final String message = result['message'] as String? ?? 'unknown error';
+      throw StateError('app.restart failed (code $code): $message');
+    }
+  }
+
+  /// Stops the running app.
+  Future<void> stop() async {
+    await _sendCommand('app.stop', {'appId': _appId!});
+  }
+
+  Future<Map<String, dynamic>> _sendCommand(
+    String method,
+    Map<String, dynamic> params,
+  ) {
+    final int id = _nextId++;
+    final Completer<Map<String, dynamic>> completer =
+        Completer<Map<String, dynamic>>();
+    _pending[id] = completer;
+    final String message =
+        '[${jsonEncode({'id': id, 'method': method, 'params': params})}]';
+    _process.stdin.writeln(message);
+    return completer.future;
+  }
+
+  void _handleLine(String line) {
+    // Daemon messages are wrapped in [ ]; ignore stray output (build logs, etc).
+    final String trimmed = line.trim();
+    if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+      // Convert regular stdio output to log messages.
+      if (!_eventController.isClosed) {
+        // The params field will be a map with the fields appId and log.
+        _eventController.add(
+          FlutterEvent('app.log', {'appId': _appId, 'log': trimmed}),
+        );
+      }
+      return;
+    }
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(trimmed);
+    } catch (_) {
+      return;
+    }
+
+    if (decoded is! List || decoded.isEmpty) return;
+    final Object? msg = decoded.first;
+    if (msg is! Map<String, dynamic>) return;
+
+    if (msg.containsKey('id')) {
+      // Response to a command we sent.
+      final int id = msg['id'] as int;
+      final Completer<Map<String, dynamic>>? completer = _pending.remove(id);
+      if (completer != null) {
+        final Object? error = msg['error'];
+        if (error != null) {
+          final String errorMsg =
+              error is Map
+                  ? (error['message'] as String? ?? '$error')
+                  : '$error';
+          completer.completeError(StateError(errorMsg));
+        } else {
+          final Object? result = msg['result'];
+          completer.complete(
+            result is Map<String, dynamic> ? result : <String, dynamic>{},
+          );
+        }
+      }
+    } else if (msg.containsKey('event')) {
+      // Unsolicited event from the daemon.
+      final String event = msg['event'] as String;
+      final Map<String, dynamic> params =
+          (msg['params'] as Map<String, dynamic>?) ?? <String, dynamic>{};
+
+      if (event == 'app.start') {
+        _appId = params['appId'] as String?;
+      } else if (event == 'app.started') {
+        if (!_startedCompleter.isCompleted) _startedCompleter.complete();
+      }
+
+      // TODO: listen for app.debugPort and read out the wsUri (vm service
+      // protocol) field
+
+      if (!_eventController.isClosed) {
+        _eventController.add(FlutterEvent(event, params));
+      }
+    }
+  }
+
+  void _handleDone() {
+    // Process stdout closed — the subprocess exited.
+    if (!_startedCompleter.isCompleted) {
+      final String stderr = _stderrLines.join('\n');
+      _startedCompleter.completeError(
+        StateError('flutter run exited before app started.\n$stderr'),
+      );
+    }
+    for (final Completer<Map<String, dynamic>> c in _pending.values) {
+      c.completeError(StateError('flutter run process exited'));
+    }
+    _pending.clear();
+    if (!_eventController.isClosed) _eventController.close();
+  }
+}

--- a/lib/src/mcp_server.dart
+++ b/lib/src/mcp_server.dart
@@ -2,15 +2,9 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:dart_mcp/server.dart';
-import 'package:flutter_daemon/flutter_daemon.dart';
 import 'package:unique_names_generator/unique_names_generator.dart';
 
-// TODO: We want to switch from using the persistent daemon process to using
-// `flutter run --machine`. This supports a subset of the daemon protocol -
-// also json over stdio - and was designed for this run-one-app use case.
-// This means we'll stop using package:flutter_daemon (and will likely roll our
-// own, miniimal library). The protocol is documented at:
-// https://github.com/flutter/flutter/blob/master/packages/flutter_tools/doc/daemon.md
+import 'flutter_run.dart';
 
 /// The MCP server for flutter-agent-tools.
 base class FlutterAgentServer extends MCPServer
@@ -31,19 +25,15 @@ base class FlutterAgentServer extends MCPServer
     registerTool(flutterCloseAppTool, _flutterCloseApp);
   }
 
-  FlutterDaemon? _daemon;
-  FlutterDaemon get _daemonInstance => _daemon ??= FlutterDaemon();
-
-  final Map<String, FlutterApplication> _sessions = {};
-  final Map<String, StreamSubscription<FlutterDaemonEvent>> _subscriptions = {};
+  final Map<String, FlutterRunSession> _sessions = {};
+  final Map<String, StreamSubscription<FlutterEvent>> _subscriptions = {};
 
   @override
   Future<void> shutdown() async {
     await Future.wait(_subscriptions.values.map((s) => s.cancel()));
     _subscriptions.clear();
-    await Future.wait(_sessions.values.map((app) => app.stop()));
+    await Future.wait(_sessions.values.map((session) => session.stop()));
     _sessions.clear();
-    await _daemon?.dispose();
     await super.shutdown();
   }
 
@@ -57,13 +47,13 @@ base class FlutterAgentServer extends MCPServer
   );
 
   String _newSessionId() {
-    final suffix =
+    final String suffix =
         List.generate(
           2,
           (_) => _random.nextInt(256).toRadixString(16).padLeft(2, '0'),
         ).join();
 
-    return [_nameGenerator.generate(), suffix].join('-');
+    return [_nameGenerator.generate(), suffix].join('_');
   }
 
   final Tool flutterLaunchAppTool = Tool(
@@ -91,35 +81,30 @@ base class FlutterAgentServer extends MCPServer
   );
 
   Future<CallToolResult> _flutterLaunchApp(CallToolRequest request) async {
-    final args = request.arguments!;
-    final workingDirectory = args['working_directory'] as String;
-    final device = args['device'] as String?;
-    final target = args['target'] as String?;
+    final Map<String, dynamic> args = request.arguments!;
+    final String workingDirectory = args['working_directory'] as String;
+    final String? device = args['device'] as String?;
+    final String? target = args['target'] as String?;
 
-    final arguments = [
-      if (device != null) ...['--device-id', device],
-      if (target != null) ...['--target', target],
-    ];
-
-    final application = await _daemonInstance.run(
-      arguments: arguments,
+    final FlutterRunSession session = await FlutterRunSession.start(
       workingDirectory: workingDirectory,
+      deviceId: device,
+      target: target,
     );
 
-    final sessionId = _newSessionId();
-
-    _sessions[sessionId] = application;
-    _watchSession(sessionId, application);
+    final String sessionId = _newSessionId();
+    _sessions[sessionId] = session;
+    _watchSession(sessionId, session);
 
     return CallToolResult(
       content: [TextContent(text: 'Launched. Session ID: $sessionId')],
     );
   }
 
-  void _watchSession(String sessionId, FlutterApplication application) {
-    const loggerId = 'flutter_agent_tools';
+  void _watchSession(String sessionId, FlutterRunSession session) {
+    const String loggerId = 'flutter_agent_tools';
 
-    _subscriptions[sessionId] = application.events.listen((event) {
+    _subscriptions[sessionId] = session.events.listen((event) {
       if (event.event == 'app.stop') {
         _releaseSession(sessionId);
 
@@ -128,14 +113,25 @@ base class FlutterAgentServer extends MCPServer
           '[$sessionId] App stopped; session released.',
           logger: loggerId,
         );
-      } else {
-        final (level, message) = _convertToLog(event);
-        if (level != null) {
-          this.log(
-            level,
-            '[$sessionId] ${event.event}: $message',
-            logger: loggerId,
-          );
+
+        return;
+      }
+
+      final (LoggingLevel? level, String? message) = _convertToLog(event);
+      if (level != null && message != null) {
+        if (event.event == 'app.log') {
+          // We special case stdio output a bit.
+          const stdioPrefix = 'flutter: ';
+
+          if (message.startsWith(stdioPrefix)) {
+            final msg = message.substring(stdioPrefix.length);
+            this.log(level, '[stdio] $msg', logger: loggerId);
+          } else {
+            // It's system output.
+            this.log(level, '[flutter] $message', logger: loggerId);
+          }
+        } else {
+          this.log(level, '[${event.event}] $message', logger: loggerId);
         }
       }
     });
@@ -181,28 +177,29 @@ base class FlutterAgentServer extends MCPServer
   );
 
   Future<CallToolResult> _flutterPerformReload(CallToolRequest request) async {
-    final sessionId = request.arguments!['session_id'] as String;
-    final application = _sessions[sessionId];
+    final String sessionId = request.arguments!['session_id'] as String;
+    final FlutterRunSession? session = _sessions[sessionId];
 
-    if (application == null) {
+    if (session == null) {
       return CallToolResult(
         isError: true,
         content: [TextContent(text: 'No session found for ID: $sessionId')],
       );
     }
 
-    final fullRestart = request.arguments!['full_restart'] as bool? ?? false;
-    await application.restart(fullRestart: fullRestart);
+    final bool fullRestart =
+        request.arguments!['full_restart'] as bool? ?? false;
+    await session.restart(fullRestart: fullRestart);
 
-    final action = fullRestart ? 'Hot restart' : 'Hot reload';
+    final String action = fullRestart ? 'Hot restart' : 'Hot reload';
     return CallToolResult(content: [TextContent(text: '$action complete.')]);
   }
 
   Future<CallToolResult> _flutterCloseApp(CallToolRequest request) async {
-    final sessionId = request.arguments!['session_id'] as String;
-    final application = _sessions.remove(sessionId);
+    final String sessionId = request.arguments!['session_id'] as String;
+    final FlutterRunSession? session = _sessions.remove(sessionId);
 
-    if (application == null) {
+    if (session == null) {
       return CallToolResult(
         isError: true,
         content: [TextContent(text: 'No session found for ID: $sessionId')],
@@ -212,25 +209,32 @@ base class FlutterAgentServer extends MCPServer
     _releaseSession(sessionId);
 
     // We don't await this call.
-    application.stop();
+    session.stop();
 
     return CallToolResult(content: [TextContent(text: 'App stopped.')]);
   }
 
-  (LoggingLevel?, String?) _convertToLog(FlutterDaemonEvent event) {
-    final params = event.params;
+  (LoggingLevel?, String?) _convertToLog(FlutterEvent event) {
+    final Map<String, dynamic> params = event.params;
 
     // By default, flatten the map.
-    var message = params.keys
-        .map((k) {
-          final v = params[k];
+    String message = params.keys
+        .map((String k) {
+          final Object? v = params[k];
           return '$k: ${v is String ? "'$v'" : v}';
         })
         .join(', ');
 
     switch (event.event) {
+      case 'app.log':
+        {
+          message = params['log'] as String? ?? message;
+          final bool isError = params['error'] as bool? ?? false;
+          return (isError ? LoggingLevel.warning : LoggingLevel.info, message);
+        }
       case 'app.progress':
         {
+          // The `progressId` field identifies the app.progress type.
           switch (params['progressId']) {
             case 'devFS.update':
               {
@@ -241,9 +245,18 @@ base class FlutterAgentServer extends MCPServer
               {
                 // We get a start and a stop event; filter the first and promote
                 // the second.
-
                 if (params['finished'] == true) {
                   return (LoggingLevel.notice, 'Hot reload finished.');
+                } else {
+                  return (null, null);
+                }
+              }
+            case 'hot.restart':
+              {
+                // We get a start and a stop event; filter the first and promote
+                // the second.
+                if (params['finished'] == true) {
+                  return (LoggingLevel.notice, 'Hot restart finished.');
                 } else {
                   return (null, null);
                 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
 
 dependencies:
   dart_mcp: ^0.5.0
-  flutter_daemon: ^1.0.1
   unique_names_generator: ^3.1.2
 
 dev_dependencies:


### PR DESCRIPTION
Replaces `package:flutter_daemon` with a small custom library that talks directly to the `flutter run --machine` JSON-RPC protocol over stdio.

- `lib/src/flutter_run.dart`: new `FlutterRunSession` class — spawns `flutter run --machine`, handles startup sequencing (waits for `app.started`), dispatches events, and routes command responses back to callers via per-request completers
- `mcp_server.dart`: updated to use `FlutterRunSession` in place of `FlutterDaemon`/`FlutterApplication`; improved log formatting for stdio vs. system output
- Removed `package:flutter_daemon` from `pubspec.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)