### PR TITLE
Improve MCP tool descriptions and trim docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,80 +5,31 @@ Dart and Flutter projects. It addresses two core failure modes: agents using
 outdated APIs due to training cutoff limitations, and agents being unable to
 observe a running Flutter app.
 
-## Project Structure
+## Key Conventions
 
-```
-flutter-agent-tools/
-├── .claude-plugin/
-│   └── plugin.json              # Plugin manifest (name, version, MCP server declarations)
-├── bin/
-│   └── mcp_server.dart          # MCP server entry point
-├── docs/
-│   ├── inspector.md             # Flutter runtime inspection guide for AI agents
-│   └── inspector_sample.json    # Sample inspector protocol traffic
-├── hooks/
-│   └── hooks.json               # PreToolUse hook configuration
-├── lib/
-│   ├── mcp_server.dart          # Library export
-│   └── src/
-│       ├── diagnostics_node.dart        # DiagnosticsNode wire representation
-│       ├── flutter_run_session.dart     # flutter run --machine subprocess manager
-│       ├── flutter_service_extensions.dart  # VM service extension wrappers
-│       └── mcp_server.dart              # FlutterAgentServer (MCPServer + ToolsSupport)
-├── scripts/
-│   ├── dep_health_check.sh      # Bash hook: validates packages before flutter pub add
-│   └── pubspec_guard.sh         # Write/Edit hook: guards direct pubspec.yaml edits (stub)
-├── test/
-│   ├── mcp_server_test.dart
-│   └── test_utils.dart
-├── tool/
-│   └── generate_readme.dart
-├── analysis_options.yaml
-├── pubspec.yaml
-├── .prettierrc
-├── CLAUDE.md
-├── DESIGN.md
-└── README.md
-```
+- MCP server entry point: `bin/mcp_server.dart`; logic:
+  `lib/src/mcp_server.dart`. Declared in `.claude-plugin/plugin.json`.
+- Hook scripts: `scripts/dep_health_check.sh` (Bash) and
+  `scripts/pubspec_guard.sh` (Write/Edit on pubspec.yaml). Configured in
+  `hooks/hooks.json`.
+- Hook scripts receive tool input as JSON on stdin; exit 0 to allow, exit 1 to
+  block.
+- Use `${CLAUDE_PLUGIN_ROOT}` for all paths in hook commands — never hardcode.
+- Fail open on infrastructure errors (missing `curl`/`jq`, network timeout):
+  don't block the agent over tooling issues.
+- The MCP server is a Dart CLI package:
+  `dart run flutter_agent_tools:mcp_server`.
 
-## Components
-
-### Hooks (shell scripts, implemented)
-
-- `dep_health_check.sh`: PreToolUse hook on Bash. Intercepts `flutter pub add` /
-  `dart pub add`, queries pub.dev, blocks discontinued packages, warns on stale
-  ones. Requires `curl` and `jq`.
-- `pubspec_guard.sh`: PreToolUse hook on Write/Edit targeting pubspec.yaml.
-  Currently a no-op stub.
-
-### MCP Server (Dart, implemented)
-
-A Dart CLI package at the repo root. Entry point is `bin/mcp_server.dart`;
-server logic lives in `lib/src/mcp_server.dart`. Declared in `plugin.json` under
-`mcpServers`.
-
-The server manages `flutter run --machine` subprocesses via `FlutterRunSession`,
-connects to the VM service via `package:vm_service`, and exposes Flutter
-inspector extensions through `FlutterServiceExtensions`.
-
-**Registered MCP tools:**
+## Registered MCP Tools
 
 - `flutter_launch_app` — builds and launches a Flutter app, returns a session ID
 - `flutter_perform_reload` — hot reload or hot restart a running app
 - `flutter_close_app` — stops a running app and releases its session
 - `flutter_take_screenshot` — captures a PNG screenshot via the inspector
   protocol
-- `flutter_debug_paint` — gets or sets the debug paint overlay
-
-## Key Conventions
-
-- Hook scripts receive tool input as JSON on stdin; exit 0 to allow, exit 1 to
-  block.
-- Use `${CLAUDE_PLUGIN_ROOT}` for all paths in hook commands — never hardcode.
-- Fail open on infrastructure errors (missing `curl`/`jq`, network timeout):
-  don't block the agent over tooling issues.
-- The MCP server is a Dart CLI package. Run via
-  `dart run flutter_agent_tools:mcp_server`.
+- `flutter_inspect_layout` — returns the layout tree for a widget (or root)
+- `flutter_evaluate_expression` — evaluates an arbitrary Dart expression on the
+  main isolate
 
 ## Current Status
 
@@ -86,8 +37,10 @@ inspector extensions through `FlutterServiceExtensions`.
 - `dep_health_check.sh`: functional (pub.dev validation, discontinuation check,
   age heuristic)
 - `pubspec_guard.sh`: stub only
-- MCP server: functional — launch, reload, close, screenshot, and debug paint
-  tools are implemented and working
+- MCP server: functional — launch, reload, close, screenshot, inspect layout,
+  and evaluate tools are implemented and working
+- Flutter.Error events are pushed to agents with widget IDs for use with
+  `flutter_inspect_layout`
 
 ## Development
 
@@ -98,9 +51,6 @@ echo '{"tool_name":"Bash","tool_input":{"command":"flutter pub add http"}}' \
 
 # Load the plugin locally:
 claude --plugin-dir /path/to/flutter-agent-tools
-
-# Reload after changes (inside a Claude Code session):
-/reload-plugins
 ```
 
 ## Design Reference

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -200,7 +200,7 @@ _Introspection and interaction (via Dart VM Service):_
   `ext.flutter.inspector.screenshot` with physical window dimensions from
   `evaluate`.
 
-### `flutter_evaluate`
+### `flutter_evaluate_expression`
 
 Runs an arbitrary Dart expression on the main isolate via the VM service
 `evaluate` RPC and returns the result as a string.
@@ -287,7 +287,7 @@ package_info(package, kind, library?, class?, version?) → String  [planned]
 ✓ flutter_take_screenshot(session_id, pixel_ratio?) → PNG
 ✓ flutter.error log events  // push; includes widget IDs for flutter_inspect_layout
 ✓ flutter_inspect_layout(session_id, widget_id?) → String  // widget_id=null → root
-✓ flutter_evaluate(session_id, expression) → String  // arbitrary Dart on main isolate
+✓ flutter_evaluate_expression(session_id, expression) → String  // arbitrary Dart on main isolate
 [planned] flutter_query_ui(session_id, mode) → String  // semantics | widget_tree | route
 
 // Tool 3 — app interaction (useful but lower priority for coding agents)

--- a/README.md
+++ b/README.md
@@ -30,14 +30,16 @@ runtime: query semantic elements, inject text, trigger taps, and pull unhandled
 exceptions from the Dart VM Service.
 
 <!-- flutter commands -->
+<!-- prettier-ignore-start -->
 | Command | Description |
 |---------|-------------|
-| `flutter_launch_app` | Builds and launches the Flutter app, returning a session ID for use with subsequent flutter_* tools. |
-| `flutter_perform_reload` | Hot reloads or hot restarts a running Flutter app. Prefer hot reload for iterative changes; use hot restart when state needs to be fully reset. |
+| `flutter_launch_app` | Builds and launches the Flutter app. Returns a session ID required by all other flutter_* tools. Call this first before inspecting, screenshotting, or evaluating. Flutter.Error events from the running app are automatically forwarded as MCP log warnings — no polling needed. |
+| `flutter_perform_reload` | Applies source file changes to a running Flutter app. Call this after editing Dart files, before taking a screenshot or inspecting layout. Prefer hot reload for iterative changes; use hot restart (full_restart: true) when state needs to be fully reset. |
+| `flutter_take_screenshot` | Captures a PNG screenshot of the running Flutter app. Use proactively after a reload to visually confirm UI changes are correct, and when diagnosing layout or rendering issues. Root widget bounds are resolved automatically. |
+| `flutter_inspect_layout` | Use when debugging layout issues, overflow errors, or unexpected widget sizing. Returns constraints, size, flex parameters, and children for a widget. Omit widget_id to start from the root. Widget IDs are included in flutter.error log events and in the output of prior inspect calls — use them to drill into a specific node. Increase subtree_depth to see deeper child layout. |
+| `flutter_evaluate_expression` | Evaluates a Dart expression on the running app's main isolate and returns the result as a string. Use for binding-layer and platform-layer state not visible in the widget tree: FlutterView properties (physicalSize, devicePixelRatio), MediaQueryData, Navigator state, or any runtime value. Runs in the root library scope, so top-level declarations and globals are in scope. Example: "WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio.toString()" |
 | `flutter_close_app` | Stops a running Flutter app and releases its session. |
-| `flutter_take_screenshot` | Takes a screenshot of the running Flutter app and returns it as a PNG image. The root widget bounds are resolved automatically. |
-| `flutter_inspect_layout` | Returns the layout details (constraints, size, flex parameters, and children) for a specific widget. Supply a widget ID from a flutter.error log event or a prior inspector call to drill into a specific node. Increase subtree_depth to see deeper child layout. Omit widget_id to inspect from the root — useful for proactive exploration. |
-| `flutter_evaluate` | Evaluates a Dart expression on the running app's main isolate and returns the result as a string. Runs in the context of the app's root library, so top-level declarations and globals are in scope. Useful for reading binding-layer state not visible in the widget tree: FlutterView properties (physicalSize, devicePixelRatio), MediaQueryData, or any other runtime value. |
+<!-- prettier-ignore-end -->
 <!-- flutter commands -->
 
 ## Installation

--- a/lib/src/mcp_server.dart
+++ b/lib/src/mcp_server.dart
@@ -23,15 +23,12 @@ base class FlutterAgentServer extends MCPServer
       ) {
     loggingLevel = LoggingLevel.info;
 
-    // session lifecycle
     registerTool(flutterLaunchAppTool, _flutterLaunchApp);
     registerTool(flutterPerformReloadTool, _flutterPerformReload);
-    registerTool(flutterCloseAppTool, _flutterCloseApp);
-
-    // inspection
     registerTool(flutterTakeScreenshotTool, _flutterTakeScreenshot);
     registerTool(flutterInspectLayoutTool, _flutterInspectLayout);
     registerTool(flutterEvaluateTool, _flutterEvaluate);
+    registerTool(flutterCloseAppTool, _flutterCloseApp);
   }
 
   final Map<String, FlutterRunSession> _sessions = {};
@@ -68,8 +65,10 @@ base class FlutterAgentServer extends MCPServer
   final Tool flutterLaunchAppTool = Tool(
     name: 'flutter_launch_app',
     description:
-        'Builds and launches the Flutter app, returning a session ID for use '
-        'with subsequent flutter_* tools.',
+        'Builds and launches the Flutter app. Returns a session ID required '
+        'by all other flutter_* tools. Call this first before inspecting, '
+        'screenshotting, or evaluating. Flutter.Error events from the running '
+        'app are automatically forwarded as MCP log warnings — no polling needed.',
     inputSchema: Schema.object(
       properties: {
         'target': Schema.string(
@@ -190,9 +189,10 @@ base class FlutterAgentServer extends MCPServer
   final Tool flutterPerformReloadTool = Tool(
     name: 'flutter_perform_reload',
     description:
-        'Hot reloads or hot restarts a running Flutter app. '
-        'Prefer hot reload for iterative changes; use hot restart when state '
-        'needs to be fully reset.',
+        'Applies source file changes to a running Flutter app. Call this '
+        'after editing Dart files, before taking a screenshot or inspecting '
+        'layout. Prefer hot reload for iterative changes; use hot restart '
+        '(full_restart: true) when state needs to be fully reset.',
     inputSchema: Schema.object(
       properties: {
         'session_id': Schema.string(
@@ -248,8 +248,10 @@ base class FlutterAgentServer extends MCPServer
   final Tool flutterTakeScreenshotTool = Tool(
     name: 'flutter_take_screenshot',
     description:
-        'Takes a screenshot of the running Flutter app and returns it as a '
-        'PNG image. The root widget bounds are resolved automatically.',
+        'Captures a PNG screenshot of the running Flutter app. Use '
+        'proactively after a reload to visually confirm UI changes are '
+        'correct, and when diagnosing layout or rendering issues. '
+        'Root widget bounds are resolved automatically.',
     inputSchema: Schema.object(
       properties: {
         'session_id': Schema.string(
@@ -291,12 +293,12 @@ base class FlutterAgentServer extends MCPServer
   final Tool flutterInspectLayoutTool = Tool(
     name: 'flutter_inspect_layout',
     description:
-        'Returns the layout details (constraints, size, flex parameters, and '
-        'children) for a specific widget. Supply a widget ID from a '
-        'flutter.error log event or a prior inspector call to drill into a '
-        'specific node. Increase subtree_depth to see deeper child layout. '
-        'Omit widget_id to inspect from the root — useful for proactive '
-        'exploration.',
+        'Use when debugging layout issues, overflow errors, or unexpected '
+        'widget sizing. Returns constraints, size, flex parameters, and '
+        'children for a widget. Omit widget_id to start from the root. '
+        'Widget IDs are included in flutter.error log events and in the '
+        'output of prior inspect calls — use them to drill into a specific '
+        'node. Increase subtree_depth to see deeper child layout.',
     inputSchema: Schema.object(
       properties: {
         'session_id': Schema.string(
@@ -351,14 +353,15 @@ base class FlutterAgentServer extends MCPServer
   }
 
   final Tool flutterEvaluateTool = Tool(
-    name: 'flutter_evaluate',
+    name: 'flutter_evaluate_expression',
     description:
         'Evaluates a Dart expression on the running app\'s main isolate and '
-        'returns the result as a string. Runs in the context of the app\'s '
-        'root library, so top-level declarations and globals are in scope. '
-        'Useful for reading binding-layer state not visible in the widget '
-        'tree: FlutterView properties (physicalSize, devicePixelRatio), '
-        'MediaQueryData, or any other runtime value.',
+        'returns the result as a string. Use for binding-layer and '
+        'platform-layer state not visible in the widget tree: FlutterView '
+        'properties (physicalSize, devicePixelRatio), MediaQueryData, '
+        'Navigator state, or any runtime value. Runs in the root library '
+        'scope, so top-level declarations and globals are in scope. '
+        'Example: "WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio.toString()"',
     inputSchema: Schema.object(
       properties: {
         'session_id': Schema.string(

--- a/tool/generate_readme.dart
+++ b/tool/generate_readme.dart
@@ -46,12 +46,14 @@ void main() async {
 
   // Build the markdown table.
   final buf = StringBuffer();
+  buf.writeln('<!-- prettier-ignore-start -->');
   buf.writeln('| Command | Description |');
   buf.writeln('|---------|-------------|');
   for (final tool in toolsResult.tools) {
     buf.write('| `${tool.name}` | ${tool.description} |');
     buf.writeln();
   }
+  buf.writeln('<!-- prettier-ignore-end -->');
 
   // Splice the table into README.md between the two markers.
   final readme = File('README.md');


### PR DESCRIPTION
Rewrites tool descriptions for better agent discoverability and trims CLAUDE.md.

- MCP tool descriptions now lead with use case and workflow cues (when to call each tool, in what order)
- Tools are registered in lifecycle order: launch → reload → screenshot → inspect → evaluate → close
- CLAUDE.md condensed: file tree removed, components section merged into conventions
- `generate_readme.dart` now emits `prettier-ignore` markers around the table so Prettier doesn't reformat it