### PR TITLE
Add go_router path enrichment to flutter_query_ui route mode

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -305,10 +305,11 @@ What it is good for:
   it reads or edits routing code.
 
 Limitations:
-- **No route path (generic).** The output contains widget class names, not route
-  strings (e.g. `/podcast/:id`). An agent that needs to call `context.go(...)`
-  still has to read the routes file to discover valid paths and their required
-  parameters.
+- **Route path (non-go_router apps).** For apps not using go_router, the output
+  contains widget class names only, not route strings. An agent that needs to
+  call `context.go(...)` still has to read the routes file to discover valid
+  paths and their required parameters. go_router apps get the actual URI via
+  `GoRouter.state.uri` (see enrichment section below).
 - **Summary tree depth.** The widget tree is fetched with `isSummaryTree: true`,
   which omits internal Flutter widgets. If a project wraps all screens in a
   private class, those wrappers may be the first locally-created widget found,
@@ -318,9 +319,9 @@ Limitations:
   suppresses navigators composed entirely of private widgets but cannot
   automatically determine which navigator is "primary" in all cases.
 
-**Route path enrichment via go_router (planned):**
+**Route path enrichment via go_router (implemented):**
 
-For apps using go_router, we can extract the actual current URI by locating
+For apps using go_router, the actual current URI is extracted by locating
 `InheritedGoRouter` in the widget tree and evaluating against its instance:
 
 1. Walk the summary tree → find `InheritedGoRouter` node → read its `valueId`
@@ -328,26 +329,35 @@ For apps using go_router, we can extract the actual current URI by locating
 2. `inspectorIdToVmObjectId(valueId)` → resolve the inspector handle to a raw
    VM object ID (`objects/1234`) by evaluating
    `WidgetInspectorService.instance.toObject(id)` in the inspector library scope
-   (see `FlutterServiceExtensions.inspectorIdToVmObjectId`).
-3. `evaluateOnObject(vmId, 'notifier.routerDelegate.currentConfiguration.uri.toString()')`
-   → returns the current path, e.g. `/podcast/123`.
+   (see `FlutterServiceExtensions.inspectorIdToVmObjectId`). Note: this returns
+   the `InheritedElement`, not the widget itself.
+3. `evaluateOnObject(vmId, 'widget.goRouter.state.uri.toString()')`
+   → `.widget` reaches the `InheritedGoRouter` widget; `.goRouter` is its
+   field (not `.notifier`); `.state.uri` gives the live current path, e.g.
+   `/podcast/787ae263b723`.
 
 Detection: presence of `InheritedGoRouter` in the summary tree is sufficient to
 identify a go_router app. Other popular routers (auto_route, beamer) follow the
 same InheritedWidget pattern but with different field names; they can be added
 as separate cases when needed.
 
+This enrichment is best-effort: if evaluation fails (e.g. older go_router
+version, or app doesn't use go_router), the route stack is still returned
+without the `Current path:` line.
+
 **Programmatic navigation via go_router (planned):**
 
 Once we have the GoRouter instance via `evaluateOnObject`, we can call navigation
-methods on it directly:
+methods on it directly. Note the field path: the VM object is an `InheritedElement`,
+so `.widget` is needed to reach the `InheritedGoRouter`, then `.goRouter` for the
+`GoRouter` instance:
 
 ```dart
 // Navigate to a new route:
-evaluateOnObject(vmId, 'notifier.go("/podcast/123")')
+evaluateOnObject(vmId, 'widget.goRouter.go("/podcast/123")')
 
 // Named location (requires knowing the route name):
-evaluateOnObject(vmId, 'notifier.namedLocation("podcast", pathParameters: {"id": "123"})')
+evaluateOnObject(vmId, 'widget.goRouter.namedLocation("podcast", pathParameters: {"id": "123"})')
 ```
 
 `go()` returns void, so the handler needs to treat a null/void `InstanceRef`
@@ -390,7 +400,7 @@ package_info(package, kind, library?, class?, version?) → String  [planned]
 ✓ flutter.error log events  // push; includes widget IDs for flutter_inspect_layout
 ✓ flutter_inspect_layout(session_id, widget_id?) → String  // widget_id=null → root
 ✓ flutter_evaluate(session_id, expression) → String  // arbitrary Dart on main isolate
-✓ flutter_query_ui(session_id, mode) → String  // route: ✓ (go_router path enrichment planned) | semantics: [planned] | widget_tree: [planned]
+✓ flutter_query_ui(session_id, mode) → String  // route: ✓ (incl. go_router path enrichment) | semantics: [planned] | widget_tree: [planned]
 [planned] flutter_navigate(session_id, path) → void  // go_router: via InheritedGoRouter + evaluateOnObject
 
 // Tool 3 — app interaction (useful but lower priority for coding agents)

--- a/lib/src/route_formatter.dart
+++ b/lib/src/route_formatter.dart
@@ -12,7 +12,10 @@ import 'diagnostics_node.dart';
 /// starting with `_`) are suppressed — they are framework or shell-route
 /// internals (e.g. go_router's `_AppShell`) that add noise without useful
 /// orientation information.
-String formatRouteInfo(DiagnosticsNode root) {
+///
+/// If [currentPath] is provided (e.g. resolved from go_router via VM service
+/// evaluate), it is included at the top of the output.
+String formatRouteInfo(DiagnosticsNode root, {String? currentPath}) {
   final navigators = <_NavigatorInfo>[];
   _collectNavigators(root, 0, navigators);
 
@@ -34,6 +37,10 @@ String formatRouteInfo(DiagnosticsNode root) {
   }
 
   final buf = StringBuffer();
+  if (currentPath != null) {
+    buf.writeln('Current path: $currentPath');
+    buf.writeln();
+  }
   for (int ni = 0; ni < visible.length; ni++) {
     final nav = visible[ni];
     // Only show the navigator header when multiple navigators are visible —
@@ -58,6 +65,32 @@ String formatRouteInfo(DiagnosticsNode root) {
   }
 
   return buf.toString().trim();
+}
+
+/// Returns all [DiagnosticsNode] instances in [root]'s subtree whose
+/// [DiagnosticsNode.widgetRuntimeType] is `InheritedGoRouter`.
+///
+/// go_router places a single `InheritedGoRouter` near the top of the tree.
+/// Its `notifier` field holds the [GoRouter] instance, which can be used (via
+/// [FlutterServiceExtensions.evaluateOnObject]) to query the current route
+/// configuration.
+///
+/// Returns an empty list if the app does not use go_router.
+List<DiagnosticsNode> findGoRouterNodes(DiagnosticsNode root) {
+  final result = <DiagnosticsNode>[];
+  _collectGoRouterNodes(root, result);
+  return result;
+}
+
+void _collectGoRouterNodes(DiagnosticsNode node, List<DiagnosticsNode> out) {
+  if (node.widgetRuntimeType == 'InheritedGoRouter') {
+    out.add(node);
+    // Don't recurse further — nested GoRouters are not a go_router pattern.
+    return;
+  }
+  for (final child in node.children) {
+    _collectGoRouterNodes(child, out);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/src/tools/flutter_query_ui.dart
+++ b/lib/src/tools/flutter_query_ui.dart
@@ -71,8 +71,35 @@ class FlutterQueryUiTool extends FlutterTool {
             isSummaryTree: true,
             fullDetails: true,
           );
+
+          // Best-effort: resolve the current go_router path via VM evaluate.
+          // Finds InheritedGoRouter in the widget tree, converts its inspector
+          // handle to a VM object ID, then evaluates widget.goRouter.state.uri.
+          String? currentPath;
+          try {
+            final goRouterNodes = findGoRouterNodes(root);
+            if (goRouterNodes.isNotEmpty) {
+              final valueId = goRouterNodes.first.valueId;
+              if (valueId != null) {
+                final vmId = await extensions.inspectorIdToVmObjectId(valueId);
+                if (vmId != null) {
+                  currentPath = await extensions.evaluateOnObject(
+                    vmId,
+                    'widget.goRouter.state.uri.toString()',
+                  );
+                }
+              }
+            }
+          } catch (_) {
+            // go_router enrichment is best-effort — proceed without path info.
+          }
+
           return CallToolResult(
-            content: [TextContent(text: formatRouteInfo(root))],
+            content: [
+              TextContent(
+                text: formatRouteInfo(root, currentPath: currentPath),
+              ),
+            ],
           );
         default:
           return CallToolResult(


### PR DESCRIPTION
Enriches `flutter_query_ui mode=route` output with the actual current URI for apps using go_router.

- Locates `InheritedGoRouter` in the summary widget tree; resolves its inspector handle to a VM object ID via `inspectorIdToVmObjectId`
- Evaluates `widget.goRouter.state.uri.toString()` on the element to get the live path (e.g. `/podcast/787ae263b723`)
- Prepends `Current path: ...` to the route mode output; silently omitted for non-go_router apps
- Adds `findGoRouterNodes()` helper to `route_formatter.dart`
- Updates `DESIGN.md`: marks enrichment implemented, corrects the `InheritedElement` → `.widget.goRouter` field path, updates planned navigation examples

Key finding during development: `inspectorIdToVmObjectId` returns the `InheritedElement`, not the widget — `.widget` is needed before `.goRouter`, and `.state.uri` gives the live location (vs. `routerDelegate.currentConfiguration.uri` which can lag).