### PR TITLE
Remove session_id from tool calls; enforce single active session

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,12 @@
 {
   "proseWrap": "always",
-  "printWidth": 80
+  "printWidth": 80,
+  "overrides": [
+    {
+      "files": "*.yaml",
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ expressions, and observe runtime errors with widget IDs.
 | `perform_scroll_until_visible` | Scrolls a Scrollable widget until a target widget is visible in the viewport. |
 | `get_semantics` | Returns a flat list of visible semantics nodes from the running Flutter app. |
 | `perform_semantic_action` | Dispatches a semantics action on a widget by its semantics node ID or label. |
-| `close_app` | Stops a running Flutter app and releases its session. |
+| `close_app` | Stops the running Flutter app and releases its session. |
 <!-- prettier-ignore-end -->
 <!-- inspector -->
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -11,7 +11,7 @@
 ## Feedback-01
 
 - [x] split the api mcp server into three tool commands
-- [ ] consider making the session_id optional; if one session just use it
+- [x] consider making the session_id optional; if one session just use it
 - [ ] when starting a session, send back a short how-to guide?
 - [x] investigate why genertics in expr eval are getting HTML-entity-encoded
       (`&lt;Type&gt;`)
@@ -44,6 +44,6 @@
 
 - [ ] explore what a guide to agents adding 'assists' to the code would look
       like (semantic nodes; something to aide navigation?)
-- [ ] explore what an in-line package could provide; would it be a big enough
+- [x] explore what an in-line package could provide; would it be a big enough
       win to recommend it? better semantic tree retrieval, better routing
       support, ...; package:slipstream_agent / package:slipstream_support

--- a/docs/slipstream_doc.md
+++ b/docs/slipstream_doc.md
@@ -1,7 +1,6 @@
 # Flutter Slipstream
 
-Generated documentation on Slipstream's MCP servers, and their instructions and
-tools.
+Generated documentation on Slipstream's MCP servers, and their instructions and tools.
 
 ## `packages` server
 
@@ -11,9 +10,7 @@ Use these tools when you need accurate, up-to-date API signatures for a package
 rather than relying on training-data summaries, which are often subtly wrong.
 
 Typical call sequence:
-
-1. package_summary — orient on the package: version, library list, exported
-   names.
+1. package_summary — orient on the package: version, library list, exported names.
 2. library_stub — get full API signatures for one library.
 3. class_stub — drill into a specific class when you know exactly what you need.
 
@@ -26,17 +23,12 @@ version in pubspec.lock, no network required.
 package_summary(project_directory, package)
 ```
 
-Returns API summaries for Dart or Flutter packages; start here to orient on an
-unfamiliar package. Use this to get accurate, version-matched API signatures
-instead of relying on training-data summaries, which are often subtly wrong.
+Returns API summaries for Dart or Flutter packages; start here to orient on an unfamiliar package. Use this to get accurate, version-matched API signatures instead of relying on training-data summaries, which are often subtly wrong.
 
-The returned package summary contains version, entry-point import, README
-excerpt, public library list, and exported name groups for the main library.
+The returned package summary contains version, entry-point import, README excerpt, public library list, and exported name groups for the main library.
 
-- `project_directory`: (required) Absolute path to the Dart/Flutter project
-  directory (the folder containing pubspec.yaml). Used to resolve the package
-  version from pubspec.lock and to locate the package_config.json for analysis.
-- `package`: (required) The package name (e.g. "http", "provider").
+- `project_directory`:  (required) Absolute path to the Dart/Flutter project directory (the folder containing pubspec.yaml). Used to resolve the package version from pubspec.lock and to locate the package_config.json for analysis.
+- `package`:  (required) The package name (e.g. "http", "provider").
 
 ### `packages:library_stub`
 
@@ -44,15 +36,11 @@ excerpt, public library list, and exported name groups for the main library.
 library_stub(project_directory, package, library_uri)
 ```
 
-Returns the full public API for one library as a Dart stub (signatures only, no
-bodies).
+Returns the full public API for one library as a Dart stub (signatures only, no bodies).
 
-- `project_directory`: (required) Absolute path to the Dart/Flutter project
-  directory (the folder containing pubspec.yaml). Used to resolve the package
-  version from pubspec.lock and to locate the package_config.json for analysis.
-- `package`: (required) The package name (e.g. "http", "provider").
-- `library_uri`: (required) The library URI to target, e.g.
-  "package:http/http.dart".
+- `project_directory`:  (required) Absolute path to the Dart/Flutter project directory (the folder containing pubspec.yaml). Used to resolve the package version from pubspec.lock and to locate the package_config.json for analysis.
+- `package`:  (required) The package name (e.g. "http", "provider").
+- `library_uri`:  (required) The library URI to target, e.g. "package:http/http.dart".
 
 ### `packages:class_stub`
 
@@ -60,56 +48,35 @@ bodies).
 class_stub(project_directory, package, library_uri, class)
 ```
 
-Returns the public API for a single named class, mixin, or extension as a Dart
-stub (signatures only, no bodies).
+Returns the public API for a single named class, mixin, or extension as a Dart stub (signatures only, no bodies).
 
-- `project_directory`: (required) Absolute path to the Dart/Flutter project
-  directory (the folder containing pubspec.yaml). Used to resolve the package
-  version from pubspec.lock and to locate the package_config.json for analysis.
-- `package`: (required) The package name (e.g. "http", "provider").
-- `library_uri`: (required) The library URI to target, e.g.
-  "package:http/http.dart".
-- `class`: (required) The class, mixin, or extension name to target (e.g.
-  "Client").
-
+- `project_directory`:  (required) Absolute path to the Dart/Flutter project directory (the folder containing pubspec.yaml). Used to resolve the package version from pubspec.lock and to locate the package_config.json for analysis.
+- `package`:  (required) The package name (e.g. "http", "provider").
+- `library_uri`:  (required) The library URI to target, e.g. "package:http/http.dart".
+- `class`:  (required) The class, mixin, or extension name to target (e.g. "Client").
 ## `inspector` server
 
 Tools for launching, inspecting, and interacting with a running Flutter app.
 
-Session lifecycle: call run_app first to get a session_id; pass it to all other
-tools. Call close_app when done.
+Session lifecycle: call run_app first to launch the app; call close_app when done. Only one app session can be active at a time — calling run_app while an app is already running will stop the previous app first.
 
 Recommended workflow for UI changes:
-
 1. Edit Dart source files.
-2. reload — applies changes without losing app state. Use full_restart: true
-   only when state must reset (e.g. initState changes).
-3. screenshot — visually confirm the change. Do this proactively; don't assume
-   the edit was correct.
-4. If the screenshot reveals a problem, use inspect_layout (for sizing/overflow
-   issues) or evaluate (for runtime state).
+2. reload — applies changes without losing app state. Use full_restart: true only when state must reset (e.g. initState changes).
+3. screenshot — visually confirm the change. Do this proactively; don't assume the edit was correct.
+4. If the screenshot reveals a problem, use inspect_layout (for sizing/overflow issues) or evaluate (for runtime state).
 
 Debugging layout issues:
-
 - inspect_layout with no widget_id starts from the root.
-- Widget IDs appear in flutter.error log events — use them to jump directly to
-  the failing widget.
+- Widget IDs appear in flutter.error log events — use them to jump directly to the failing widget.
 - Increase subtree_depth to see deeper into the tree.
 
 Orientation:
+- get_route shows the current navigator stack with screen widget names and source locations. Use this to confirm which screen is active before inspecting or editing.
+- get_semantics lists visible, interactive nodes with their IDs. Pass node IDs directly to 'perform_semantic_action'.
+- If the app has slipstream_agent installed, use 'perform_tap', 'perform_set_text', 'perform_scroll', or 'perform_scroll_until_visible' instead of 'perform_semantic_action' — these support byKey/byType/byText finders and do not require semantics annotations.
 
-- get_route shows the current navigator stack with screen widget names and
-  source locations. Use this to confirm which screen is active before inspecting
-  or editing.
-- get_semantics lists visible, interactive nodes with their IDs. Pass node IDs
-  directly to 'perform_semantic_action'.
-- If the app has slipstream_agent installed, use 'perform_tap',
-  'perform_set_text', 'perform_scroll', or 'perform_scroll_until_visible'
-  instead of 'perform_semantic_action' — these support byKey/byType/byText
-  finders and do not require semantics annotations.
-
-Flutter.Error events are forwarded automatically as MCP log warnings — no
-polling needed. They include widget IDs for use with inspect_layout.
+Flutter.Error events are forwarded automatically as MCP log warnings — no polling needed. They include widget IDs for use with inspect_layout.
 
 ### `inspector:run_app`
 
@@ -117,281 +84,187 @@ polling needed. They include widget IDs for use with inspect_layout.
 run_app(working_directory, [target, device])
 ```
 
-Builds and launches the Flutter app. Returns a session ID required by all other
-tools. Call this first before inspecting, screenshotting, or evaluating.
-Flutter.Error events from the running app are automatically forwarded as MCP log
-warnings — no polling needed.
+Builds and launches the Flutter app. Call this first before inspecting, screenshotting, or evaluating. If an app is already running it is stopped and replaced. Flutter.Error events from the running app are automatically forwarded as MCP log warnings — no polling needed.
 
-- `working_directory`: (required) The Flutter project directory to launch.
-- `target`: The main entry point to launch (e.g. lib/main.dart). Defaults to the
-  project default.
-- `device`: Optional device ID override. When omitted, auto-selects the best
-  available device (prefers desktop for fast builds). Only pass this if the user
-  requests a specific device.
+- `working_directory`:  (required) The Flutter project directory to launch.
+- `target`: The main entry point to launch (e.g. lib/main.dart). Defaults to the project default.
+- `device`: Optional device ID override. When omitted, auto-selects the best available device (prefers desktop for fast builds). Only pass this if the user requests a specific device.
 
 ### `inspector:reload`
 
 ```
-reload(session_id, [full_restart])
+reload([full_restart])
 ```
 
-Applies source file changes to a running Flutter app. Call this after editing
-Dart files, before taking a screenshot or inspecting layout. Prefer hot reload
-for iterative changes; use hot restart (full_restart: true) when state needs to
-be fully reset.
+Applies source file changes to a running Flutter app. Call this after editing Dart files, before taking a screenshot or inspecting layout. Prefer hot reload for iterative changes; use hot restart (full_restart: true) when state needs to be fully reset.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `full_restart`: If true, performs a hot restart instead of a hot reload.
-  Defaults to false.
+- `full_restart`: If true, performs a hot restart instead of a hot reload. Defaults to false.
 
 ### `inspector:take_screenshot`
 
 ```
-take_screenshot(session_id, [pixel_ratio])
+take_screenshot([pixel_ratio])
 ```
 
-Captures a PNG screenshot of the running Flutter app. Use proactively after a
-reload to visually confirm UI changes are correct, and when diagnosing layout or
-rendering issues. Root widget bounds are resolved automatically. Note: only the
-Flutter view is captured — native system UI such as platform share sheets,
-permission dialogs, or OS-level overlays will not appear in the screenshot even
-if visible on screen.
+Captures a PNG screenshot of the running Flutter app. Use proactively after a reload to visually confirm UI changes are correct, and when diagnosing layout or rendering issues. Root widget bounds are resolved automatically. Note: only the Flutter view is captured — native system UI such as platform share sheets, permission dialogs, or OS-level overlays will not appear in the screenshot even if visible on screen.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `pixel_ratio`: Device pixel ratio for the screenshot. Higher values produce
-  sharper images. Defaults to 1.0.
+- `pixel_ratio`: Device pixel ratio for the screenshot. Higher values produce sharper images. Defaults to 1.0.
 
 ### `inspector:inspect_layout`
 
 ```
-inspect_layout(session_id, [widget_id, subtree_depth])
+inspect_layout([widget_id, subtree_depth])
 ```
 
-Use when debugging layout issues, overflow errors, or unexpected widget sizing.
-Returns constraints, size, flex parameters, and children for a widget. Omit
-widget_id to start from the root. Widget IDs are included in flutter.error log
-events and in the output of prior inspect calls — use them to drill into a
-specific node. Increase subtree_depth to see deeper child layout.
+Use when debugging layout issues, overflow errors, or unexpected widget sizing. Returns constraints, size, flex parameters, and children for a widget. Omit widget_id to start from the root. Widget IDs are included in flutter.error log events and in the output of prior inspect calls — use them to drill into a specific node. Increase subtree_depth to see deeper child layout.
 
-- `session_id`: (required) The session ID returned by run_app.
 - `widget_id`: The widget ID to inspect. Omit to start from the root widget.
 - `subtree_depth`: How many levels of children to include. Defaults to 1.
 
 ### `inspector:evaluate`
 
 ```
-evaluate(session_id, expression, [library_uri])
+evaluate(expression, [library_uri])
 ```
 
-Evaluates a Dart expression on the running app's main isolate and returns the
-result as a string. Use for binding-layer and platform-layer state not visible
-in the widget tree: FlutterView properties (physicalSize, devicePixelRatio),
-MediaQueryData, or any runtime value. By default runs in the root library scope
-(main.dart), so top-level declarations and globals are in scope. Pass
-library_uri to evaluate in a different library scope — for example,
-"package:flutter/src/widgets/widget_inspector.dart" makes RendererBinding,
-SemanticsNode, CheckedState, and Tristate available.
+Evaluates a Dart expression on the running app's main isolate and returns the result as a string. Use for binding-layer and platform-layer state not visible in the widget tree: FlutterView properties (physicalSize, devicePixelRatio), MediaQueryData, or any runtime value. By default runs in the root library scope (main.dart), so top-level declarations and globals are in scope. Pass library_uri to evaluate in a different library scope — for example, "package:flutter/src/widgets/widget_inspector.dart" makes RendererBinding, SemanticsNode, CheckedState, and Tristate available.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `expression`: (required) The Dart expression to evaluate. Must produce a value
-  with a useful toString(). Example:
-  "WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio.toString()"
-- `library_uri`: Optional. The URI of the library scope in which to evaluate the
-  expression. Defaults to the app's root library (main.dart). Use
-  "package:flutter/src/widgets/widget_inspector.dart" to access Flutter
-  rendering and semantics APIs such as RendererBinding, SemanticsNode,
-  CheckedState, and Tristate.
+- `expression`:  (required) The Dart expression to evaluate. Must produce a value with a useful toString(). Example: "WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio.toString()"
+- `library_uri`: Optional. The URI of the library scope in which to evaluate the expression. Defaults to the app's root library (main.dart). Use "package:flutter/src/widgets/widget_inspector.dart" to access Flutter rendering and semantics APIs such as RendererBinding, SemanticsNode, CheckedState, and Tristate.
 
 ### `inspector:get_route`
 
 ```
-get_route(session_id)
+get_route()
 ```
 
-Returns the current navigator route stack with screen widget names and source
-locations. Use this to confirm which screen is active before inspecting or
-editing, or to answer "what screen is the app on?" questions. Enriches the stack
-with the current router path when the slipstream_agent companion is installed
-with a router adapter.
+Returns the current navigator route stack with screen widget names and source locations. Use this to confirm which screen is active before inspecting or editing, or to answer "what screen is the app on?" questions. Enriches the stack with the current router path when the slipstream_agent companion is installed with a router adapter.
 
-- `session_id`: (required) The session ID returned by run_app.
 
 ### `inspector:navigate`
 
 ```
-navigate(session_id, path)
+navigate(path)
 ```
 
-Navigates the app to a route path. Requires the slipstream_agent companion
-package with a router adapter registered via SlipstreamAgent.init(router:
-GoRouterAdapter(appRouter)).
+Navigates the app to a route path. Requires the slipstream_agent companion package with a router adapter registered via SlipstreamAgent.init(router: GoRouterAdapter(appRouter)).
 
-Supports any routing library for which an adapter exists: GoRouter, AutoRouter,
-Beamer, or a custom adapter. Use get_route first to see the current path and
-understand the app's route structure.
+Supports any routing library for which an adapter exists: GoRouter, AutoRouter, Beamer, or a custom adapter. Use get_route first to see the current path and understand the app's route structure.
 
 Example path: "/podcast/123".
 
-- `session_id`: (required) The session ID returned by run_app.
-- `path`: (required) The route path to navigate to. Must start with "/".
-  Example: "/podcast/123".
+- `path`:  (required) The route path to navigate to. Must start with "/". Example: "/podcast/123".
 
 ### `inspector:perform_tap`
 
 ```
-perform_tap(session_id, finder, finder_value)
+perform_tap(finder, finder_value)
 ```
 
-Taps a widget located by a finder. Synthesizes a pointer down/up event at the
-widget's center — triggers GestureDetector.onTap, InkWell.onTap, and any other
-gesture recognizers.
+Taps a widget located by a finder. Synthesizes a pointer down/up event at the widget's center — triggers GestureDetector.onTap, InkWell.onTap, and any other gesture recognizers.
 
-Finders: byKey (ValueKey string), byType (widget type name, e.g.
-"ElevatedButton"), byText (Text widget content), bySemanticsLabel (Semantics
-widget label).
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "ElevatedButton"), byText (Text widget content), bySemanticsLabel (Semantics widget label).
 
-Requires the slipstream_agent companion package. Without it, use
-perform_semantic_action with action "tap" instead.
+Requires the slipstream_agent companion package. Without it, use perform_semantic_action with action "tap" instead.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `finder`: (required) How to find the widget: "byKey", "byType", "byText", or
-  "bySemanticsLabel".
-- `finder_value`: (required) The value to match against the chosen finder.
+- `finder`:  (required) How to find the widget: "byKey", "byType", "byText", or "bySemanticsLabel".
+- `finder_value`:  (required) The value to match against the chosen finder.
 
 ### `inspector:perform_set_text`
 
 ```
-perform_set_text(session_id, finder, finder_value, text)
+perform_set_text(finder, finder_value, text)
 ```
 
-Sets the text content of a text field located by a finder. Replaces the field's
-current content entirely via the EditableText controller — no keyboard
-simulation needed.
+Sets the text content of a text field located by a finder. Replaces the field's current content and fires the field's onChanged callback. Note: TextInputFormatters are not applied since text is set directly without going through the input pipeline.
 
-Finders: byKey (ValueKey string), byType (widget type name, e.g. "TextField"),
-byText (Text widget content), bySemanticsLabel (Semantics widget label).
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "TextField"), byText (Text widget content), bySemanticsLabel (Semantics widget label).
 
-Tip: call perform_tap on the field first if the app requires focus before
-accepting text input.
+Tip: call perform_tap on the field first if the app requires focus before accepting text input.
 
-Requires the slipstream_agent companion package. Without it, use
-perform_semantic_action with action "setText" instead.
+Requires the slipstream_agent companion package. Without it, use perform_semantic_action with action "setText" instead.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `finder`: (required) How to find the widget: "byKey", "byType", "byText", or
-  "bySemanticsLabel".
-- `finder_value`: (required) The value to match against the chosen finder.
-- `text`: (required) The text to set. Replaces the field's current content.
+- `finder`:  (required) How to find the widget: "byKey", "byType", "byText", or "bySemanticsLabel".
+- `finder_value`:  (required) The value to match against the chosen finder.
+- `text`:  (required) The text to set. Replaces the field's current content.
 
 ### `inspector:perform_scroll`
 
 ```
-perform_scroll(session_id, finder, finder_value, direction, pixels)
+perform_scroll(finder, finder_value, direction, pixels)
 ```
 
-Scrolls a Scrollable widget by a fixed number of logical pixels. The finder
-locates the Scrollable (e.g. ListView, SingleChildScrollView) directly. Clamped
-to the scroll extent bounds.
+Scrolls a Scrollable widget by a fixed number of logical pixels. The finder locates the Scrollable (e.g. ListView, SingleChildScrollView) directly. Clamped to the scroll extent bounds.
 
-Finders: byKey (ValueKey string), byType (widget type name, e.g. "ListView"),
-byText (Text widget content), bySemanticsLabel (Semantics widget label).
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "ListView"), byText (Text widget content), bySemanticsLabel (Semantics widget label).
 
 To bring a specific widget into view, use perform_scroll_until_visible instead.
 
 Requires the slipstream_agent companion package.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `finder`: (required) How to find the Scrollable widget: "byKey", "byType",
-  "byText", or "bySemanticsLabel".
-- `finder_value`: (required) The value to match against the chosen finder.
-- `direction`: (required) Scroll direction: "up", "down", "left", or "right".
-- `pixels`: (required) Number of logical pixels to scroll.
+- `finder`:  (required) How to find the Scrollable widget: "byKey", "byType", "byText", or "bySemanticsLabel".
+- `finder_value`:  (required) The value to match against the chosen finder.
+- `direction`:  (required) Scroll direction: "up", "down", "left", or "right".
+- `pixels`:  (required) Number of logical pixels to scroll.
 
 ### `inspector:perform_scroll_until_visible`
 
 ```
-perform_scroll_until_visible(session_id, finder, finder_value, scroll_finder, scroll_finder_value)
+perform_scroll_until_visible(finder, finder_value, scroll_finder, scroll_finder_value)
 ```
 
-Scrolls a Scrollable widget until a target widget is visible in the viewport.
-Two finders are required: one to locate the target widget, and one to locate the
-Scrollable that contains it.
+Scrolls a Scrollable widget until a target widget is visible in the viewport. Two finders are required: one to locate the target widget, and one to locate the Scrollable that contains it.
 
-Finders for both: byKey (ValueKey string), byType (widget type name), byText
-(Text widget content), bySemanticsLabel (Semantics label).
+Finders for both: byKey (ValueKey string), byType (widget type name), byText (Text widget content), bySemanticsLabel (Semantics label).
 
-Example: scroll a ListView (scroll_finder="byType",
-scroll_finder_value="ListView") until item_42 is visible (finder="byKey",
-finder_value="item_42").
+Example: scroll a ListView (scroll_finder="byType", scroll_finder_value="ListView") until item_42 is visible (finder="byKey", finder_value="item_42").
 
 Requires the slipstream_agent companion package.
 
-- `session_id`: (required) The session ID returned by run_app.
-- `finder`: (required) How to find the target widget: "byKey", "byType",
-  "byText", or "bySemanticsLabel".
-- `finder_value`: (required) The value to match against the target finder.
-- `scroll_finder`: (required) How to find the Scrollable: "byKey", "byType",
-  "byText", or "bySemanticsLabel".
-- `scroll_finder_value`: (required) The value to match against the scroll
-  finder.
+- `finder`:  (required) How to find the target widget: "byKey", "byType", "byText", or "bySemanticsLabel".
+- `finder_value`:  (required) The value to match against the target finder.
+- `scroll_finder`:  (required) How to find the Scrollable: "byKey", "byType", "byText", or "bySemanticsLabel".
+- `scroll_finder_value`:  (required) The value to match against the scroll finder.
 
 ### `inspector:get_semantics`
 
 ```
-get_semantics(session_id)
+get_semantics()
 ```
 
-Returns a flat list of visible semantics nodes from the running Flutter app.
-Each node shows its role, ID, state flags, supported actions, label, and size.
-Use this to find what is on screen and what can be interacted with. Node IDs
-from this output can be passed directly to 'tap' and 'set_text'. Node IDs are
-stable until the next hot reload or hot restart.
+Returns a flat list of visible semantics nodes from the running Flutter app. Each node shows its role, ID, state flags, supported actions, label, and size. Use this to find what is on screen and what can be interacted with. Node IDs from this output can be passed directly to 'perform_semantic_action'. Node IDs are stable until the next hot reload or hot restart.
 
-- `session_id`: (required) The session ID returned by run_app.
 
 ### `inspector:perform_semantic_action`
 
 ```
-perform_semantic_action(session_id, action, [node_id, label, value])
+perform_semantic_action(action, [node_id, label, value])
 ```
 
-Dispatches a semantics action on a widget by its semantics node ID or label.
-Works without the slipstream_agent companion package, but requires the target
-widget to have a semantics node.
+Dispatches a semantics action on a widget by its semantics node ID or label. Works without the slipstream_agent companion package, but requires the target widget to have a semantics node.
 
 Common actions:
+  - tap — tap a button, list item, or any tappable widget
+  - setText — set text field content; provide "value" with the text
+  - longPress — long-press a widget
+  - focus — move keyboard focus to an input field
+  - scrollUp / scrollDown — scroll a scrollable widget
+  - increase / decrease — adjust a slider or stepper
 
-- tap — tap a button, list item, or any tappable widget
-- setText — set text field content; provide "value" with the text
-- longPress — long-press a widget
-- focus — move keyboard focus to an input field
-- scrollUp / scrollDown — scroll a scrollable widget
-- increase / decrease — adjust a slider or stepper
+One of "node_id" or "label" must be provided. Prefer "node_id" when available (faster — skips tree fetch). Use get_semantics first to see available nodes and their IDs.
 
-One of "node_id" or "label" must be provided. Prefer "node_id" when available
-(faster — skips tree fetch). Use get_semantics first to see available nodes and
-their IDs.
+For apps with the slipstream_agent companion installed, prefer perform_tap, perform_set_text, perform_scroll, or perform_scroll_until_visible — they support byKey/byType/byText finders and do not require semantics annotations.
 
-For apps with the slipstream_agent companion installed, prefer the `interact`
-tool — it supports byKey/byType/byText finders and does not require semantics
-annotations.
-
-- `session_id`: (required) The session ID returned by run_app.
-- `action`: (required) The SemanticsAction to dispatch. Common values: tap,
-  setText, longPress, focus, scrollUp, scrollDown, increase, decrease.
-- `node_id`: The semantics node ID. Shown as "id=N" in get_semantics output.
-  Prefer this over "label" when you already know the ID.
-- `label`: Dispatch to the first visible node whose label contains this text
-  (case-insensitive substring match). Ignored if "node_id" is provided.
-- `value`: Required for the setText action. Replaces the field's current content
-  entirely. Ignored for other actions.
+- `action`:  (required) The SemanticsAction to dispatch. Common values: tap, setText, longPress, focus, scrollUp, scrollDown, increase, decrease.
+- `node_id`: The semantics node ID. Shown as "id=N" in get_semantics output. Prefer this over "label" when you already know the ID.
+- `label`: Dispatch to the first visible node whose label contains this text (case-insensitive substring match). Ignored if "node_id" is provided.
+- `value`: Required for the setText action. Replaces the field's current content entirely. Ignored for other actions.
 
 ### `inspector:close_app`
 
 ```
-close_app(session_id)
+close_app()
 ```
 
-Stops a running Flutter app and releases its session.
+Stops the running Flutter app and releases its session.
 
-- `session_id`: (required) The session ID returned by run_app.

--- a/docs/slipstream_doc.md
+++ b/docs/slipstream_doc.md
@@ -1,6 +1,7 @@
 # Flutter Slipstream
 
-Generated documentation on Slipstream's MCP servers, and their instructions and tools.
+Generated documentation on Slipstream's MCP servers, and their instructions and
+tools.
 
 ## `packages` server
 
@@ -10,7 +11,9 @@ Use these tools when you need accurate, up-to-date API signatures for a package
 rather than relying on training-data summaries, which are often subtly wrong.
 
 Typical call sequence:
-1. package_summary — orient on the package: version, library list, exported names.
+
+1. package_summary — orient on the package: version, library list, exported
+   names.
 2. library_stub — get full API signatures for one library.
 3. class_stub — drill into a specific class when you know exactly what you need.
 
@@ -23,12 +26,17 @@ version in pubspec.lock, no network required.
 package_summary(project_directory, package)
 ```
 
-Returns API summaries for Dart or Flutter packages; start here to orient on an unfamiliar package. Use this to get accurate, version-matched API signatures instead of relying on training-data summaries, which are often subtly wrong.
+Returns API summaries for Dart or Flutter packages; start here to orient on an
+unfamiliar package. Use this to get accurate, version-matched API signatures
+instead of relying on training-data summaries, which are often subtly wrong.
 
-The returned package summary contains version, entry-point import, README excerpt, public library list, and exported name groups for the main library.
+The returned package summary contains version, entry-point import, README
+excerpt, public library list, and exported name groups for the main library.
 
-- `project_directory`:  (required) Absolute path to the Dart/Flutter project directory (the folder containing pubspec.yaml). Used to resolve the package version from pubspec.lock and to locate the package_config.json for analysis.
-- `package`:  (required) The package name (e.g. "http", "provider").
+- `project_directory`: (required) Absolute path to the Dart/Flutter project
+  directory (the folder containing pubspec.yaml). Used to resolve the package
+  version from pubspec.lock and to locate the package_config.json for analysis.
+- `package`: (required) The package name (e.g. "http", "provider").
 
 ### `packages:library_stub`
 
@@ -36,11 +44,15 @@ The returned package summary contains version, entry-point import, README excerp
 library_stub(project_directory, package, library_uri)
 ```
 
-Returns the full public API for one library as a Dart stub (signatures only, no bodies).
+Returns the full public API for one library as a Dart stub (signatures only, no
+bodies).
 
-- `project_directory`:  (required) Absolute path to the Dart/Flutter project directory (the folder containing pubspec.yaml). Used to resolve the package version from pubspec.lock and to locate the package_config.json for analysis.
-- `package`:  (required) The package name (e.g. "http", "provider").
-- `library_uri`:  (required) The library URI to target, e.g. "package:http/http.dart".
+- `project_directory`: (required) Absolute path to the Dart/Flutter project
+  directory (the folder containing pubspec.yaml). Used to resolve the package
+  version from pubspec.lock and to locate the package_config.json for analysis.
+- `package`: (required) The package name (e.g. "http", "provider").
+- `library_uri`: (required) The library URI to target, e.g.
+  "package:http/http.dart".
 
 ### `packages:class_stub`
 
@@ -48,35 +60,57 @@ Returns the full public API for one library as a Dart stub (signatures only, no 
 class_stub(project_directory, package, library_uri, class)
 ```
 
-Returns the public API for a single named class, mixin, or extension as a Dart stub (signatures only, no bodies).
+Returns the public API for a single named class, mixin, or extension as a Dart
+stub (signatures only, no bodies).
 
-- `project_directory`:  (required) Absolute path to the Dart/Flutter project directory (the folder containing pubspec.yaml). Used to resolve the package version from pubspec.lock and to locate the package_config.json for analysis.
-- `package`:  (required) The package name (e.g. "http", "provider").
-- `library_uri`:  (required) The library URI to target, e.g. "package:http/http.dart".
-- `class`:  (required) The class, mixin, or extension name to target (e.g. "Client").
+- `project_directory`: (required) Absolute path to the Dart/Flutter project
+  directory (the folder containing pubspec.yaml). Used to resolve the package
+  version from pubspec.lock and to locate the package_config.json for analysis.
+- `package`: (required) The package name (e.g. "http", "provider").
+- `library_uri`: (required) The library URI to target, e.g.
+  "package:http/http.dart".
+- `class`: (required) The class, mixin, or extension name to target (e.g.
+  "Client").
+
 ## `inspector` server
 
 Tools for launching, inspecting, and interacting with a running Flutter app.
 
-Session lifecycle: call run_app first to launch the app; call close_app when done. Only one app session can be active at a time — calling run_app while an app is already running will stop the previous app first.
+Session lifecycle: call run_app first to launch the app; call close_app when
+done. Only one app session can be active at a time — calling run_app while an
+app is already running will stop the previous app first.
 
 Recommended workflow for UI changes:
+
 1. Edit Dart source files.
-2. reload — applies changes without losing app state. Use full_restart: true only when state must reset (e.g. initState changes).
-3. screenshot — visually confirm the change. Do this proactively; don't assume the edit was correct.
-4. If the screenshot reveals a problem, use inspect_layout (for sizing/overflow issues) or evaluate (for runtime state).
+2. reload — applies changes without losing app state. Use full_restart: true
+   only when state must reset (e.g. initState changes).
+3. screenshot — visually confirm the change. Do this proactively; don't assume
+   the edit was correct.
+4. If the screenshot reveals a problem, use inspect_layout (for sizing/overflow
+   issues) or evaluate (for runtime state).
 
 Debugging layout issues:
+
 - inspect_layout with no widget_id starts from the root.
-- Widget IDs appear in flutter.error log events — use them to jump directly to the failing widget.
+- Widget IDs appear in flutter.error log events — use them to jump directly to
+  the failing widget.
 - Increase subtree_depth to see deeper into the tree.
 
 Orientation:
-- get_route shows the current navigator stack with screen widget names and source locations. Use this to confirm which screen is active before inspecting or editing.
-- get_semantics lists visible, interactive nodes with their IDs. Pass node IDs directly to 'perform_semantic_action'.
-- If the app has slipstream_agent installed, use 'perform_tap', 'perform_set_text', 'perform_scroll', or 'perform_scroll_until_visible' instead of 'perform_semantic_action' — these support byKey/byType/byText finders and do not require semantics annotations.
 
-Flutter.Error events are forwarded automatically as MCP log warnings — no polling needed. They include widget IDs for use with inspect_layout.
+- get_route shows the current navigator stack with screen widget names and
+  source locations. Use this to confirm which screen is active before inspecting
+  or editing.
+- get_semantics lists visible, interactive nodes with their IDs. Pass node IDs
+  directly to 'perform_semantic_action'.
+- If the app has slipstream_agent installed, use 'perform_tap',
+  'perform_set_text', 'perform_scroll', or 'perform_scroll_until_visible'
+  instead of 'perform_semantic_action' — these support byKey/byType/byText
+  finders and do not require semantics annotations.
+
+Flutter.Error events are forwarded automatically as MCP log warnings — no
+polling needed. They include widget IDs for use with inspect_layout.
 
 ### `inspector:run_app`
 
@@ -84,11 +118,17 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
 run_app(working_directory, [target, device])
 ```
 
-Builds and launches the Flutter app. Call this first before inspecting, screenshotting, or evaluating. If an app is already running it is stopped and replaced. Flutter.Error events from the running app are automatically forwarded as MCP log warnings — no polling needed.
+Builds and launches the Flutter app. Call this first before inspecting,
+screenshotting, or evaluating. If an app is already running it is stopped and
+replaced. Flutter.Error events from the running app are automatically forwarded
+as MCP log warnings — no polling needed.
 
-- `working_directory`:  (required) The Flutter project directory to launch.
-- `target`: The main entry point to launch (e.g. lib/main.dart). Defaults to the project default.
-- `device`: Optional device ID override. When omitted, auto-selects the best available device (prefers desktop for fast builds). Only pass this if the user requests a specific device.
+- `working_directory`: (required) The Flutter project directory to launch.
+- `target`: The main entry point to launch (e.g. lib/main.dart). Defaults to the
+  project default.
+- `device`: Optional device ID override. When omitted, auto-selects the best
+  available device (prefers desktop for fast builds). Only pass this if the user
+  requests a specific device.
 
 ### `inspector:reload`
 
@@ -96,9 +136,13 @@ Builds and launches the Flutter app. Call this first before inspecting, screensh
 reload([full_restart])
 ```
 
-Applies source file changes to a running Flutter app. Call this after editing Dart files, before taking a screenshot or inspecting layout. Prefer hot reload for iterative changes; use hot restart (full_restart: true) when state needs to be fully reset.
+Applies source file changes to a running Flutter app. Call this after editing
+Dart files, before taking a screenshot or inspecting layout. Prefer hot reload
+for iterative changes; use hot restart (full_restart: true) when state needs to
+be fully reset.
 
-- `full_restart`: If true, performs a hot restart instead of a hot reload. Defaults to false.
+- `full_restart`: If true, performs a hot restart instead of a hot reload.
+  Defaults to false.
 
 ### `inspector:take_screenshot`
 
@@ -106,9 +150,15 @@ Applies source file changes to a running Flutter app. Call this after editing Da
 take_screenshot([pixel_ratio])
 ```
 
-Captures a PNG screenshot of the running Flutter app. Use proactively after a reload to visually confirm UI changes are correct, and when diagnosing layout or rendering issues. Root widget bounds are resolved automatically. Note: only the Flutter view is captured — native system UI such as platform share sheets, permission dialogs, or OS-level overlays will not appear in the screenshot even if visible on screen.
+Captures a PNG screenshot of the running Flutter app. Use proactively after a
+reload to visually confirm UI changes are correct, and when diagnosing layout or
+rendering issues. Root widget bounds are resolved automatically. Note: only the
+Flutter view is captured — native system UI such as platform share sheets,
+permission dialogs, or OS-level overlays will not appear in the screenshot even
+if visible on screen.
 
-- `pixel_ratio`: Device pixel ratio for the screenshot. Higher values produce sharper images. Defaults to 1.0.
+- `pixel_ratio`: Device pixel ratio for the screenshot. Higher values produce
+  sharper images. Defaults to 1.0.
 
 ### `inspector:inspect_layout`
 
@@ -116,7 +166,11 @@ Captures a PNG screenshot of the running Flutter app. Use proactively after a re
 inspect_layout([widget_id, subtree_depth])
 ```
 
-Use when debugging layout issues, overflow errors, or unexpected widget sizing. Returns constraints, size, flex parameters, and children for a widget. Omit widget_id to start from the root. Widget IDs are included in flutter.error log events and in the output of prior inspect calls — use them to drill into a specific node. Increase subtree_depth to see deeper child layout.
+Use when debugging layout issues, overflow errors, or unexpected widget sizing.
+Returns constraints, size, flex parameters, and children for a widget. Omit
+widget_id to start from the root. Widget IDs are included in flutter.error log
+events and in the output of prior inspect calls — use them to drill into a
+specific node. Increase subtree_depth to see deeper child layout.
 
 - `widget_id`: The widget ID to inspect. Omit to start from the root widget.
 - `subtree_depth`: How many levels of children to include. Defaults to 1.
@@ -127,10 +181,23 @@ Use when debugging layout issues, overflow errors, or unexpected widget sizing. 
 evaluate(expression, [library_uri])
 ```
 
-Evaluates a Dart expression on the running app's main isolate and returns the result as a string. Use for binding-layer and platform-layer state not visible in the widget tree: FlutterView properties (physicalSize, devicePixelRatio), MediaQueryData, or any runtime value. By default runs in the root library scope (main.dart), so top-level declarations and globals are in scope. Pass library_uri to evaluate in a different library scope — for example, "package:flutter/src/widgets/widget_inspector.dart" makes RendererBinding, SemanticsNode, CheckedState, and Tristate available.
+Evaluates a Dart expression on the running app's main isolate and returns the
+result as a string. Use for binding-layer and platform-layer state not visible
+in the widget tree: FlutterView properties (physicalSize, devicePixelRatio),
+MediaQueryData, or any runtime value. By default runs in the root library scope
+(main.dart), so top-level declarations and globals are in scope. Pass
+library_uri to evaluate in a different library scope — for example,
+"package:flutter/src/widgets/widget_inspector.dart" makes RendererBinding,
+SemanticsNode, CheckedState, and Tristate available.
 
-- `expression`:  (required) The Dart expression to evaluate. Must produce a value with a useful toString(). Example: "WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio.toString()"
-- `library_uri`: Optional. The URI of the library scope in which to evaluate the expression. Defaults to the app's root library (main.dart). Use "package:flutter/src/widgets/widget_inspector.dart" to access Flutter rendering and semantics APIs such as RendererBinding, SemanticsNode, CheckedState, and Tristate.
+- `expression`: (required) The Dart expression to evaluate. Must produce a value
+  with a useful toString(). Example:
+  "WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio.toString()"
+- `library_uri`: Optional. The URI of the library scope in which to evaluate the
+  expression. Defaults to the app's root library (main.dart). Use
+  "package:flutter/src/widgets/widget_inspector.dart" to access Flutter
+  rendering and semantics APIs such as RendererBinding, SemanticsNode,
+  CheckedState, and Tristate.
 
 ### `inspector:get_route`
 
@@ -138,8 +205,11 @@ Evaluates a Dart expression on the running app's main isolate and returns the re
 get_route()
 ```
 
-Returns the current navigator route stack with screen widget names and source locations. Use this to confirm which screen is active before inspecting or editing, or to answer "what screen is the app on?" questions. Enriches the stack with the current router path when the slipstream_agent companion is installed with a router adapter.
-
+Returns the current navigator route stack with screen widget names and source
+locations. Use this to confirm which screen is active before inspecting or
+editing, or to answer "what screen is the app on?" questions. Enriches the stack
+with the current router path when the slipstream_agent companion is installed
+with a router adapter.
 
 ### `inspector:navigate`
 
@@ -147,13 +217,18 @@ Returns the current navigator route stack with screen widget names and source lo
 navigate(path)
 ```
 
-Navigates the app to a route path. Requires the slipstream_agent companion package with a router adapter registered via SlipstreamAgent.init(router: GoRouterAdapter(appRouter)).
+Navigates the app to a route path. Requires the slipstream_agent companion
+package with a router adapter registered via SlipstreamAgent.init(router:
+GoRouterAdapter(appRouter)).
 
-Supports any routing library for which an adapter exists: GoRouter, AutoRouter, Beamer, or a custom adapter. Use get_route first to see the current path and understand the app's route structure.
+Supports any routing library for which an adapter exists: GoRouter, AutoRouter,
+Beamer, or a custom adapter. Use get_route first to see the current path and
+understand the app's route structure.
 
 Example path: "/podcast/123".
 
-- `path`:  (required) The route path to navigate to. Must start with "/". Example: "/podcast/123".
+- `path`: (required) The route path to navigate to. Must start with "/".
+  Example: "/podcast/123".
 
 ### `inspector:perform_tap`
 
@@ -161,14 +236,20 @@ Example path: "/podcast/123".
 perform_tap(finder, finder_value)
 ```
 
-Taps a widget located by a finder. Synthesizes a pointer down/up event at the widget's center — triggers GestureDetector.onTap, InkWell.onTap, and any other gesture recognizers.
+Taps a widget located by a finder. Synthesizes a pointer down/up event at the
+widget's center — triggers GestureDetector.onTap, InkWell.onTap, and any other
+gesture recognizers.
 
-Finders: byKey (ValueKey string), byType (widget type name, e.g. "ElevatedButton"), byText (Text widget content), bySemanticsLabel (Semantics widget label).
+Finders: byKey (ValueKey string), byType (widget type name, e.g.
+"ElevatedButton"), byText (Text widget content), bySemanticsLabel (Semantics
+widget label).
 
-Requires the slipstream_agent companion package. Without it, use perform_semantic_action with action "tap" instead.
+Requires the slipstream_agent companion package. Without it, use
+perform_semantic_action with action "tap" instead.
 
-- `finder`:  (required) How to find the widget: "byKey", "byType", "byText", or "bySemanticsLabel".
-- `finder_value`:  (required) The value to match against the chosen finder.
+- `finder`: (required) How to find the widget: "byKey", "byType", "byText", or
+  "bySemanticsLabel".
+- `finder_value`: (required) The value to match against the chosen finder.
 
 ### `inspector:perform_set_text`
 
@@ -176,17 +257,24 @@ Requires the slipstream_agent companion package. Without it, use perform_semanti
 perform_set_text(finder, finder_value, text)
 ```
 
-Sets the text content of a text field located by a finder. Replaces the field's current content and fires the field's onChanged callback. Note: TextInputFormatters are not applied since text is set directly without going through the input pipeline.
+Sets the text content of a text field located by a finder. Replaces the field's
+current content and fires the field's onChanged callback. Note:
+TextInputFormatters are not applied since text is set directly without going
+through the input pipeline.
 
-Finders: byKey (ValueKey string), byType (widget type name, e.g. "TextField"), byText (Text widget content), bySemanticsLabel (Semantics widget label).
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "TextField"),
+byText (Text widget content), bySemanticsLabel (Semantics widget label).
 
-Tip: call perform_tap on the field first if the app requires focus before accepting text input.
+Tip: call perform_tap on the field first if the app requires focus before
+accepting text input.
 
-Requires the slipstream_agent companion package. Without it, use perform_semantic_action with action "setText" instead.
+Requires the slipstream_agent companion package. Without it, use
+perform_semantic_action with action "setText" instead.
 
-- `finder`:  (required) How to find the widget: "byKey", "byType", "byText", or "bySemanticsLabel".
-- `finder_value`:  (required) The value to match against the chosen finder.
-- `text`:  (required) The text to set. Replaces the field's current content.
+- `finder`: (required) How to find the widget: "byKey", "byType", "byText", or
+  "bySemanticsLabel".
+- `finder_value`: (required) The value to match against the chosen finder.
+- `text`: (required) The text to set. Replaces the field's current content.
 
 ### `inspector:perform_scroll`
 
@@ -194,18 +282,22 @@ Requires the slipstream_agent companion package. Without it, use perform_semanti
 perform_scroll(finder, finder_value, direction, pixels)
 ```
 
-Scrolls a Scrollable widget by a fixed number of logical pixels. The finder locates the Scrollable (e.g. ListView, SingleChildScrollView) directly. Clamped to the scroll extent bounds.
+Scrolls a Scrollable widget by a fixed number of logical pixels. The finder
+locates the Scrollable (e.g. ListView, SingleChildScrollView) directly. Clamped
+to the scroll extent bounds.
 
-Finders: byKey (ValueKey string), byType (widget type name, e.g. "ListView"), byText (Text widget content), bySemanticsLabel (Semantics widget label).
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "ListView"),
+byText (Text widget content), bySemanticsLabel (Semantics widget label).
 
 To bring a specific widget into view, use perform_scroll_until_visible instead.
 
 Requires the slipstream_agent companion package.
 
-- `finder`:  (required) How to find the Scrollable widget: "byKey", "byType", "byText", or "bySemanticsLabel".
-- `finder_value`:  (required) The value to match against the chosen finder.
-- `direction`:  (required) Scroll direction: "up", "down", "left", or "right".
-- `pixels`:  (required) Number of logical pixels to scroll.
+- `finder`: (required) How to find the Scrollable widget: "byKey", "byType",
+  "byText", or "bySemanticsLabel".
+- `finder_value`: (required) The value to match against the chosen finder.
+- `direction`: (required) Scroll direction: "up", "down", "left", or "right".
+- `pixels`: (required) Number of logical pixels to scroll.
 
 ### `inspector:perform_scroll_until_visible`
 
@@ -213,18 +305,26 @@ Requires the slipstream_agent companion package.
 perform_scroll_until_visible(finder, finder_value, scroll_finder, scroll_finder_value)
 ```
 
-Scrolls a Scrollable widget until a target widget is visible in the viewport. Two finders are required: one to locate the target widget, and one to locate the Scrollable that contains it.
+Scrolls a Scrollable widget until a target widget is visible in the viewport.
+Two finders are required: one to locate the target widget, and one to locate the
+Scrollable that contains it.
 
-Finders for both: byKey (ValueKey string), byType (widget type name), byText (Text widget content), bySemanticsLabel (Semantics label).
+Finders for both: byKey (ValueKey string), byType (widget type name), byText
+(Text widget content), bySemanticsLabel (Semantics label).
 
-Example: scroll a ListView (scroll_finder="byType", scroll_finder_value="ListView") until item_42 is visible (finder="byKey", finder_value="item_42").
+Example: scroll a ListView (scroll_finder="byType",
+scroll_finder_value="ListView") until item_42 is visible (finder="byKey",
+finder_value="item_42").
 
 Requires the slipstream_agent companion package.
 
-- `finder`:  (required) How to find the target widget: "byKey", "byType", "byText", or "bySemanticsLabel".
-- `finder_value`:  (required) The value to match against the target finder.
-- `scroll_finder`:  (required) How to find the Scrollable: "byKey", "byType", "byText", or "bySemanticsLabel".
-- `scroll_finder_value`:  (required) The value to match against the scroll finder.
+- `finder`: (required) How to find the target widget: "byKey", "byType",
+  "byText", or "bySemanticsLabel".
+- `finder_value`: (required) The value to match against the target finder.
+- `scroll_finder`: (required) How to find the Scrollable: "byKey", "byType",
+  "byText", or "bySemanticsLabel".
+- `scroll_finder_value`: (required) The value to match against the scroll
+  finder.
 
 ### `inspector:get_semantics`
 
@@ -232,8 +332,11 @@ Requires the slipstream_agent companion package.
 get_semantics()
 ```
 
-Returns a flat list of visible semantics nodes from the running Flutter app. Each node shows its role, ID, state flags, supported actions, label, and size. Use this to find what is on screen and what can be interacted with. Node IDs from this output can be passed directly to 'perform_semantic_action'. Node IDs are stable until the next hot reload or hot restart.
-
+Returns a flat list of visible semantics nodes from the running Flutter app.
+Each node shows its role, ID, state flags, supported actions, label, and size.
+Use this to find what is on screen and what can be interacted with. Node IDs
+from this output can be passed directly to 'perform_semantic_action'. Node IDs
+are stable until the next hot reload or hot restart.
 
 ### `inspector:perform_semantic_action`
 
@@ -241,24 +344,35 @@ Returns a flat list of visible semantics nodes from the running Flutter app. Eac
 perform_semantic_action(action, [node_id, label, value])
 ```
 
-Dispatches a semantics action on a widget by its semantics node ID or label. Works without the slipstream_agent companion package, but requires the target widget to have a semantics node.
+Dispatches a semantics action on a widget by its semantics node ID or label.
+Works without the slipstream_agent companion package, but requires the target
+widget to have a semantics node.
 
 Common actions:
-  - tap — tap a button, list item, or any tappable widget
-  - setText — set text field content; provide "value" with the text
-  - longPress — long-press a widget
-  - focus — move keyboard focus to an input field
-  - scrollUp / scrollDown — scroll a scrollable widget
-  - increase / decrease — adjust a slider or stepper
 
-One of "node_id" or "label" must be provided. Prefer "node_id" when available (faster — skips tree fetch). Use get_semantics first to see available nodes and their IDs.
+- tap — tap a button, list item, or any tappable widget
+- setText — set text field content; provide "value" with the text
+- longPress — long-press a widget
+- focus — move keyboard focus to an input field
+- scrollUp / scrollDown — scroll a scrollable widget
+- increase / decrease — adjust a slider or stepper
 
-For apps with the slipstream_agent companion installed, prefer perform_tap, perform_set_text, perform_scroll, or perform_scroll_until_visible — they support byKey/byType/byText finders and do not require semantics annotations.
+One of "node_id" or "label" must be provided. Prefer "node_id" when available
+(faster — skips tree fetch). Use get_semantics first to see available nodes and
+their IDs.
 
-- `action`:  (required) The SemanticsAction to dispatch. Common values: tap, setText, longPress, focus, scrollUp, scrollDown, increase, decrease.
-- `node_id`: The semantics node ID. Shown as "id=N" in get_semantics output. Prefer this over "label" when you already know the ID.
-- `label`: Dispatch to the first visible node whose label contains this text (case-insensitive substring match). Ignored if "node_id" is provided.
-- `value`: Required for the setText action. Replaces the field's current content entirely. Ignored for other actions.
+For apps with the slipstream_agent companion installed, prefer perform_tap,
+perform_set_text, perform_scroll, or perform_scroll_until_visible — they support
+byKey/byType/byText finders and do not require semantics annotations.
+
+- `action`: (required) The SemanticsAction to dispatch. Common values: tap,
+  setText, longPress, focus, scrollUp, scrollDown, increase, decrease.
+- `node_id`: The semantics node ID. Shown as "id=N" in get_semantics output.
+  Prefer this over "label" when you already know the ID.
+- `label`: Dispatch to the first visible node whose label contains this text
+  (case-insensitive substring match). Ignored if "node_id" is provided.
+- `value`: Required for the setText action. Replaces the field's current content
+  entirely. Ignored for other actions.
 
 ### `inspector:close_app`
 
@@ -267,4 +381,3 @@ close_app()
 ```
 
 Stops the running Flutter app and releases its session.
-

--- a/lib/src/inspector/inspector_mcp.dart
+++ b/lib/src/inspector/inspector_mcp.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math' show Random;
 
 import 'package:dart_mcp/server.dart';
 
@@ -23,18 +22,13 @@ import 'tools/take_screenshot_tool.dart';
 
 /// The MCP server for the runtime inspector feature.
 ///
-/// Owns the session map and event-to-log translation. Tool implementations
+/// Owns the session and event-to-log translation. Tool implementations
 /// live in lib/src/tools/ and are decoupled from this class via [ToolContext].
 base class InspectorMCPServer extends MCPServer
     with ToolsSupport, LoggingSupport {
   static const String _loggerId = 'flutter_agent_tools';
 
-  final Map<String, AppSession> _sessions = {};
-
-  final IdGenerator _idGenerator = IdGenerator();
-
   late final ToolContext _context = ToolContext(
-    sessions: _sessions,
     log: (level, message) => log(level, message, logger: _loggerId),
   );
 
@@ -47,7 +41,7 @@ base class InspectorMCPServer extends MCPServer
         instructions: '''
 Tools for launching, inspecting, and interacting with a running Flutter app.
 
-Session lifecycle: call run_app first to get a session_id; pass it to all other tools. Call close_app when done.
+Session lifecycle: call run_app first to launch the app; call close_app when done. Only one app session can be active at a time — calling run_app while an app is already running will stop the previous app first.
 
 Recommended workflow for UI changes:
 1. Edit Dart source files.
@@ -91,8 +85,7 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
 
     register(
       RunAppTool(
-        sessionIdGenerator: _idGenerator.createNextId,
-        registerSession: (id, session) => _sessions[id] = session,
+        registerSession: _registerSession,
         eventListener: _handleEvent,
       ),
     );
@@ -111,21 +104,33 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
     register(CloseAppTool());
   }
 
+  /// Registers [session] as the active session, stopping any existing one.
+  Future<void> _registerSession(AppSession session) async {
+    final existing = _context.removeSession();
+    if (existing != null) {
+      await existing.stop().timeout(
+        Duration(milliseconds: 250),
+        onTimeout: () => null,
+      );
+    }
+    _context.setSession(session);
+  }
+
   @override
   Future<void> shutdown() async {
-    await Future.wait(_sessions.values.map((session) => session.stop()));
-    _sessions.clear();
+    final session = _context.removeSession();
+    if (session != null) await session.stop();
 
     await super.shutdown();
   }
 
-  void _handleEvent(String sessionId, DaemonEvent event) {
+  void _handleEvent(DaemonEvent event) {
     if (event.event == 'app.stop') {
-      _sessions.remove(sessionId);
+      _context.removeSession();
 
       log(
         LoggingLevel.info,
-        '[$sessionId] App stopped; session released.',
+        'App stopped; session released.',
         logger: _loggerId,
       );
       return;
@@ -200,29 +205,5 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
     }
 
     return (LoggingLevel.info, message);
-  }
-}
-
-class IdGenerator {
-  static const List<String> _adjectives = [
-    'bright', 'calm', 'cozy', 'crisp', 'deft', 'fair', 'fond', 'free', 'glad',
-    'keen', 'kind', 'lush', 'mild', 'mint', 'neat', 'nimble', 'pure', 'rosy',
-    'sage', 'snug', 'soft', 'spry', 'sunny', 'swift', 'warm', 'wise', 'witty',
-    'zippy', //
-  ];
-
-  static const List<String> _animals = [
-    'bee', 'cat', 'colt', 'deer', 'dove', 'duck', 'fawn', 'finch', 'fox',
-    'frog', 'gull', 'hare', 'hawk', 'jay', 'koi', 'lamb', 'lark', 'lynx',
-    'newt', 'owl', 'pony', 'quail', 'robin', 'seal', 'swan', 'teal', 'wren', //
-  ];
-
-  final Random _random = Random();
-
-  String createNextId() {
-    final adjective = _adjectives[_random.nextInt(_adjectives.length)];
-    final animal = _animals[_random.nextInt(_animals.length)];
-    final number = _random.nextInt(100).toString().padLeft(2, '0');
-    return '${adjective}_${animal}_$number';
   }
 }

--- a/lib/src/inspector/layout_formatter.dart
+++ b/lib/src/inspector/layout_formatter.dart
@@ -27,6 +27,17 @@ String formatLayoutDetails(
     final desc = prop.description;
     if (name.isNotEmpty && desc.isNotEmpty) {
       buf.writeln('  $name: $desc');
+      // For renderObject, also show its layout properties (size, constraints,
+      // parentData) indented beneath it.
+      if (name == 'renderObject') {
+        for (final subProp in prop.properties) {
+          final subName = subProp.name ?? '';
+          final subDesc = subProp.description;
+          if (_childLayoutProps.contains(subName) && subDesc.isNotEmpty) {
+            buf.writeln('    $subName: $subDesc');
+          }
+        }
+      }
     }
   }
 
@@ -67,6 +78,18 @@ void _writeChildren(
       final desc = prop.description;
       if (_childLayoutProps.contains(name) && desc.isNotEmpty) {
         buf.writeln('$pad    $name: $desc');
+      }
+    }
+    // Layout properties (size, constraints, parentData) are nested under the
+    // renderObject sub-property in Flutter's diagnostic tree.
+    final renderObj = child.propertyNamed('renderObject');
+    if (renderObj != null) {
+      for (final subProp in renderObj.properties) {
+        final name = subProp.name ?? '';
+        final desc = subProp.description;
+        if (_childLayoutProps.contains(name) && desc.isNotEmpty) {
+          buf.writeln('$pad    $name: $desc');
+        }
       }
     }
     _writeChildren(

--- a/lib/src/inspector/tool_context.dart
+++ b/lib/src/inspector/tool_context.dart
@@ -30,25 +30,39 @@ abstract class InspectorTool {
 /// [FlutterAgentServer], keeping them decoupled from the MCP server
 /// infrastructure and easier to test independently.
 class ToolContext {
-  ToolContext({required Map<String, AppSession> sessions, required this.log})
-    : _sessions = sessions;
+  ToolContext({required this.log});
 
-  final Map<String, AppSession> _sessions;
+  AppSession? _session;
 
   /// Logs a message at the given level to the MCP client.
   final void Function(LoggingLevel level, String message) log;
 
-  /// Returns the session for [sessionId], or null if not found.
-  AppSession? session(String? sessionId) => _sessions[sessionId];
+  /// The currently active app session, or null if no app is running.
+  AppSession? get activeSession => _session;
 
-  /// Removes and returns the session for [sessionId], or null if not found.
-  AppSession? removeSession(String? sessionId) => _sessions.remove(sessionId);
+  /// Registers [session] as the active session.
+  void setSession(AppSession session) {
+    _session = session;
+  }
 
-  /// Returns an error result indicating no session was found for [sessionId].
-  CallToolResult unknownSession(String? sessionId) {
+  /// Removes and returns the active session, or null if none is running.
+  AppSession? removeSession() {
+    final s = _session;
+    _session = null;
+    return s;
+  }
+
+  /// Returns an error result indicating no app session is active.
+  CallToolResult noActiveSession() {
     return CallToolResult(
       isError: true,
-      content: [TextContent(text: 'No session found for ID: $sessionId')],
+      content: [
+        TextContent(
+          text:
+              'No app is currently running. Call run_app first to launch the '
+              'Flutter app.',
+        ),
+      ],
     );
   }
 

--- a/lib/src/inspector/tools/close_app_tool.dart
+++ b/lib/src/inspector/tools/close_app_tool.dart
@@ -4,22 +4,15 @@ import '../tool_context.dart';
 
 /// Implements the `close_app` MCP tool.
 ///
-/// Stops a running Flutter app and releases its session.
+/// Stops the running Flutter app and releases its session.
 class CloseAppTool extends InspectorTool {
   CloseAppTool();
 
   @override
   final Tool definition = Tool(
     name: 'close_app',
-    description: 'Stops a running Flutter app and releases its session.',
-    inputSchema: Schema.object(
-      properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
-      },
-      required: ['session_id'],
-    ),
+    description: 'Stops the running Flutter app and releases its session.',
+    inputSchema: Schema.object(properties: {}, required: []),
   );
 
   @override
@@ -27,20 +20,18 @@ class CloseAppTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    context.validateParams(request, definition.inputSchema.required!);
-
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.removeSession(sessionId);
+    final session = context.removeSession();
     if (session == null) {
-      return context.unknownSession(sessionId);
+      return CallToolResult(
+        content: [TextContent(text: 'No app was running.')],
+      );
     }
 
-    // Don't wait more than 250ms for the call to complete.
     await session.stop().timeout(
       Duration(milliseconds: 250),
       onTimeout: () => null,
     );
 
-    return CallToolResult(content: [TextContent(text: 'App stopped.')]);
+    return CallToolResult(content: [TextContent(text: 'Closed app.')]);
   }
 }

--- a/lib/src/inspector/tools/evaluate_tool.dart
+++ b/lib/src/inspector/tools/evaluate_tool.dart
@@ -23,9 +23,6 @@ class EvaluateTool extends InspectorTool {
         'RendererBinding, SemanticsNode, CheckedState, and Tristate available.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'expression': Schema.string(
           description:
               'The Dart expression to evaluate. Must produce a value with a '
@@ -42,7 +39,7 @@ class EvaluateTool extends InspectorTool {
               'RendererBinding, SemanticsNode, CheckedState, and Tristate.',
         ),
       },
-      required: ['session_id', 'expression'],
+      required: ['expression'],
     ),
   );
 
@@ -51,11 +48,10 @@ class EvaluateTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    final String? sessionId = request.arguments!['session_id'] as String?;
-    final session = context.session(sessionId);
-    if (sessionId == null || session == null) {
-      return context.unknownSession(sessionId);
-    }
+    context.validateParams(request, definition.inputSchema.required!);
+
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     // Unescape HTML entities that models sometimes introduce when generating
     // expressions containing generic type parameters (e.g. &lt;T&gt; → <T>).

--- a/lib/src/inspector/tools/evaluate_tool.dart
+++ b/lib/src/inspector/tools/evaluate_tool.dart
@@ -69,7 +69,8 @@ class EvaluateTool extends InspectorTool {
         expression,
         libraryUri: libraryUri,
       );
-      return CallToolResult(content: [TextContent(text: result)]);
+      final String text = result.isEmpty ? "''" : result;
+      return CallToolResult(content: [TextContent(text: text)]);
     } on RPCError catch (e) {
       return context.rpcError(e);
     }

--- a/lib/src/inspector/tools/get_route_tool.dart
+++ b/lib/src/inspector/tools/get_route_tool.dart
@@ -19,14 +19,7 @@ class GetRouteTool extends InspectorTool {
         'before inspecting or editing, or to answer "what screen is the app '
         'on?" questions. Enriches the stack with the current router path when '
         'the slipstream_agent companion is installed with a router adapter.',
-    inputSchema: Schema.object(
-      properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
-      },
-      required: ['session_id'],
-    ),
+    inputSchema: Schema.object(properties: {}, required: []),
   );
 
   @override
@@ -34,11 +27,8 @@ class GetRouteTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    final String? sessionId = request.arguments!['session_id'] as String?;
-    final session = context.session(sessionId);
-    if (sessionId == null || session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     try {
       final extensions = session.serviceExtensions!;

--- a/lib/src/inspector/tools/get_semantics_tool.dart
+++ b/lib/src/inspector/tools/get_semantics_tool.dart
@@ -18,17 +18,10 @@ class GetSemanticsTool extends InspectorTool {
         'Flutter app. Each node shows its role, ID, state flags, supported '
         'actions, label, and size. '
         'Use this to find what is on screen and what can be interacted with. '
-        "Node IDs from this output can be passed directly to 'tap' "
-        "and 'set_text'. "
+        "Node IDs from this output can be passed directly to "
+        "'perform_semantic_action'. "
         'Node IDs are stable until the next hot reload or hot restart.',
-    inputSchema: Schema.object(
-      properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
-      },
-      required: ['session_id'],
-    ),
+    inputSchema: Schema.object(properties: {}, required: []),
   );
 
   @override
@@ -36,11 +29,8 @@ class GetSemanticsTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    final String? sessionId = request.arguments!['session_id'] as String?;
-    final session = context.session(sessionId);
-    if (sessionId == null || session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     try {
       final List<SemanticNode> nodes =

--- a/lib/src/inspector/tools/inspect_layout_tool.dart
+++ b/lib/src/inspector/tools/inspect_layout_tool.dart
@@ -52,14 +52,28 @@ class InspectLayoutTool extends InspectorTool {
       if (widgetId != null) {
         resolvedId = widgetId;
       } else {
-        final root = await extensions.getRootWidget();
-        if (root.valueId == null) {
-          return CallToolResult(
-            isError: true,
-            content: [TextContent(text: 'Root widget has no valueId.')],
-          );
+        // Use the summary tree to start from the first user-created widget,
+        // skipping internal Flutter framework wrappers (View, RawView, etc.)
+        // which are 10+ levels above app code and make inspect_layout useless
+        // at default subtree depths.
+        final summaryRoot = await extensions.getRootWidgetTree(
+          isSummaryTree: true,
+        );
+        final appRoot =
+            summaryRoot.children.isNotEmpty ? summaryRoot.children.first : null;
+        if (appRoot?.valueId != null) {
+          resolvedId = appRoot!.valueId!;
+        } else {
+          // Fall back to the raw root widget.
+          final root = await extensions.getRootWidget();
+          if (root.valueId == null) {
+            return CallToolResult(
+              isError: true,
+              content: [TextContent(text: 'Root widget has no valueId.')],
+            );
+          }
+          resolvedId = root.valueId!;
         }
-        resolvedId = root.valueId!;
       }
       final node = await extensions.getDetailsSubtree(
         resolvedId,

--- a/lib/src/inspector/tools/inspect_layout_tool.dart
+++ b/lib/src/inspector/tools/inspect_layout_tool.dart
@@ -22,9 +22,6 @@ class InspectLayoutTool extends InspectorTool {
         'node. Increase subtree_depth to see deeper child layout.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'widget_id': Schema.string(
           description:
               'The widget ID to inspect. Omit to start from the root widget.',
@@ -33,7 +30,7 @@ class InspectLayoutTool extends InspectorTool {
           description: 'How many levels of children to include. Defaults to 1.',
         ),
       },
-      required: ['session_id'],
+      required: [],
     ),
   );
 
@@ -42,11 +39,8 @@ class InspectLayoutTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    final String? sessionId = request.arguments!['session_id'] as String?;
-    final session = context.session(sessionId);
-    if (sessionId == null || session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     final String? widgetId = request.arguments!['widget_id'] as String?;
     final int subtreeDepth =

--- a/lib/src/inspector/tools/navigate_tool.dart
+++ b/lib/src/inspector/tools/navigate_tool.dart
@@ -27,16 +27,13 @@ class NavigateTool extends InspectorTool {
         'Example path: "/podcast/123".',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'path': Schema.string(
           description:
               'The route path to navigate to. Must start with "/". '
               'Example: "/podcast/123".',
         ),
       },
-      required: ['session_id', 'path'],
+      required: ['path'],
     ),
   );
 
@@ -47,11 +44,8 @@ class NavigateTool extends InspectorTool {
   ) async {
     context.validateParams(request, definition.inputSchema.required!);
 
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     if (!session.hasCompanion) {
       return CallToolResult(

--- a/lib/src/inspector/tools/perform_scroll_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_tool.dart
@@ -28,9 +28,6 @@ class PerformScrollTool extends InspectorTool {
         'Requires the slipstream_agent companion package.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'finder': Schema.string(description: _finderDescription),
         'finder_value': Schema.string(description: _finderValueDescription),
         'direction': Schema.string(
@@ -40,7 +37,7 @@ class PerformScrollTool extends InspectorTool {
           description: 'Number of logical pixels to scroll.',
         ),
       },
-      required: ['session_id', 'finder', 'finder_value', 'direction', 'pixels'],
+      required: ['finder', 'finder_value', 'direction', 'pixels'],
     ),
   );
 
@@ -51,9 +48,8 @@ class PerformScrollTool extends InspectorTool {
   ) async {
     context.validateParams(request, definition.inputSchema.required!);
 
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) return context.unknownSession(sessionId);
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
     if (!session.hasCompanion) {
       return context.companionNotInstalled('perform_scroll');
     }

--- a/lib/src/inspector/tools/perform_scroll_until_visible_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_until_visible_tool.dart
@@ -23,9 +23,6 @@ class PerformScrollUntilVisibleTool extends InspectorTool {
         'Requires the slipstream_agent companion package.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'finder': Schema.string(
           description:
               'How to find the target widget: "byKey", "byType", "byText", or '
@@ -44,7 +41,6 @@ class PerformScrollUntilVisibleTool extends InspectorTool {
         ),
       },
       required: [
-        'session_id',
         'finder',
         'finder_value',
         'scroll_finder',
@@ -60,9 +56,8 @@ class PerformScrollUntilVisibleTool extends InspectorTool {
   ) async {
     context.validateParams(request, definition.inputSchema.required!);
 
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) return context.unknownSession(sessionId);
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
     if (!session.hasCompanion) {
       return context.companionNotInstalled('perform_scroll_until_visible');
     }

--- a/lib/src/inspector/tools/perform_semantic_action_tool.dart
+++ b/lib/src/inspector/tools/perform_semantic_action_tool.dart
@@ -11,7 +11,7 @@ import '../tool_context.dart';
 /// companion package but requires the target widget to have a semantics node.
 ///
 /// For richer targeting (byKey, byType, byText) without semantics annotations,
-/// install the slipstream_agent companion package and use the `interact` tool.
+/// install the slipstream_agent companion package and use the perform_* tools.
 class PerformSemanticActionTool extends InspectorTool {
   @override
   final Tool definition = Tool(
@@ -30,14 +30,12 @@ class PerformSemanticActionTool extends InspectorTool {
         'One of "node_id" or "label" must be provided. Prefer "node_id" when '
         'available (faster — skips tree fetch). Use get_semantics first to see '
         'available nodes and their IDs.\n\n'
-        'For apps with the slipstream_agent companion installed, prefer the '
-        '`interact` tool — it supports byKey/byType/byText finders and does '
-        'not require semantics annotations.',
+        'For apps with the slipstream_agent companion installed, prefer '
+        'perform_tap, perform_set_text, perform_scroll, or '
+        'perform_scroll_until_visible — they support byKey/byType/byText '
+        'finders and do not require semantics annotations.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'action': Schema.string(
           description:
               'The SemanticsAction to dispatch. Common values: tap, setText, '
@@ -60,7 +58,7 @@ class PerformSemanticActionTool extends InspectorTool {
               'content entirely. Ignored for other actions.',
         ),
       },
-      required: ['session_id', 'action'],
+      required: ['action'],
     ),
   );
 
@@ -71,11 +69,8 @@ class PerformSemanticActionTool extends InspectorTool {
   ) async {
     context.validateParams(request, definition.inputSchema.required!);
 
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     final String action = request.arguments!['action'] as String;
     final int? nodeId = coerceInt(request.arguments!['node_id']);

--- a/lib/src/inspector/tools/perform_set_text_tool.dart
+++ b/lib/src/inspector/tools/perform_set_text_tool.dart
@@ -19,8 +19,9 @@ class PerformSetTextTool extends InspectorTool {
     name: 'perform_set_text',
     description:
         'Sets the text content of a text field located by a finder. Replaces '
-        'the field\'s current content entirely via the EditableText controller '
-        '— no keyboard simulation needed.\n\n'
+        'the field\'s current content and fires the field\'s onChanged '
+        'callback. Note: TextInputFormatters are not applied since text is set '
+        'directly without going through the input pipeline.\n\n'
         'Finders: byKey (ValueKey string), byType (widget type name, e.g. '
         '"TextField"), byText (Text widget content), bySemanticsLabel '
         '(Semantics widget label).\n\n'

--- a/lib/src/inspector/tools/perform_set_text_tool.dart
+++ b/lib/src/inspector/tools/perform_set_text_tool.dart
@@ -31,9 +31,6 @@ class PerformSetTextTool extends InspectorTool {
         'perform_semantic_action with action "setText" instead.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'finder': Schema.string(description: _finderDescription),
         'finder_value': Schema.string(description: _finderValueDescription),
         'text': Schema.string(
@@ -41,7 +38,7 @@ class PerformSetTextTool extends InspectorTool {
               'The text to set. Replaces the field\'s current content.',
         ),
       },
-      required: ['session_id', 'finder', 'finder_value', 'text'],
+      required: ['finder', 'finder_value', 'text'],
     ),
   );
 
@@ -52,9 +49,8 @@ class PerformSetTextTool extends InspectorTool {
   ) async {
     context.validateParams(request, definition.inputSchema.required!);
 
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) return context.unknownSession(sessionId);
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
     if (!session.hasCompanion) {
       return context.companionNotInstalled('perform_set_text');
     }

--- a/lib/src/inspector/tools/perform_tap_tool.dart
+++ b/lib/src/inspector/tools/perform_tap_tool.dart
@@ -28,13 +28,10 @@ class PerformTapTool extends InspectorTool {
         'perform_semantic_action with action "tap" instead.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'finder': Schema.string(description: _finderDescription),
         'finder_value': Schema.string(description: _finderValueDescription),
       },
-      required: ['session_id', 'finder', 'finder_value'],
+      required: ['finder', 'finder_value'],
     ),
   );
 
@@ -45,9 +42,8 @@ class PerformTapTool extends InspectorTool {
   ) async {
     context.validateParams(request, definition.inputSchema.required!);
 
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) return context.unknownSession(sessionId);
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
     if (!session.hasCompanion) {
       return context.companionNotInstalled('perform_tap');
     }

--- a/lib/src/inspector/tools/reload_tool.dart
+++ b/lib/src/inspector/tools/reload_tool.dart
@@ -18,16 +18,13 @@ class ReloadTool extends InspectorTool {
         '(full_restart: true) when state needs to be fully reset.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'full_restart': Schema.bool(
           description:
               'If true, performs a hot restart instead of a hot reload. '
               'Defaults to false.',
         ),
       },
-      required: ['session_id'],
+      required: [],
     ),
   );
 
@@ -36,11 +33,8 @@ class ReloadTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    final String? sessionId = request.arguments!['session_id'] as String?;
-    final session = context.session(sessionId);
-    if (sessionId == null || session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     final bool fullRestart =
         coerceBool(request.arguments!['full_restart']) ?? false;

--- a/lib/src/inspector/tools/run_app_tool.dart
+++ b/lib/src/inspector/tools/run_app_tool.dart
@@ -5,32 +5,27 @@ import '../tool_context.dart';
 
 /// Implements the `run_app` MCP tool.
 ///
-/// Builds and launches a Flutter app, returning a session ID for use with
-/// all other inspector tools.
+/// Builds and launches a Flutter app. If an app is already running it is
+/// stopped first — only one session is active at a time.
 class RunAppTool extends InspectorTool {
-  RunAppTool({
-    required this.sessionIdGenerator,
-    required this.registerSession,
-    required this.eventListener,
-  });
+  RunAppTool({required this.registerSession, required this.eventListener});
 
-  /// Called to generate a unique session ID for the new session.
-  final String Function() sessionIdGenerator;
-
-  /// Called to register a new [AppSession] under [sessionId].
-  final void Function(String sessionId, AppSession session) registerSession;
+  /// Called to register the new [AppSession] as the active session. Any
+  /// previously active session is stopped by the caller before this returns.
+  final Future<void> Function(AppSession session) registerSession;
 
   /// Called to forward daemon events from the session to the server.
-  final void Function(String sessionId, DaemonEvent event) eventListener;
+  final void Function(DaemonEvent event) eventListener;
 
   @override
   final Tool definition = Tool(
     name: 'run_app',
     description:
-        'Builds and launches the Flutter app. Returns a session ID required '
-        'by all other tools. Call this first before inspecting, '
-        'screenshotting, or evaluating. Flutter.Error events from the running '
-        'app are automatically forwarded as MCP log warnings — no polling needed.',
+        'Builds and launches the Flutter app. Call this first before '
+        'inspecting, screenshotting, or evaluating. If an app is already '
+        'running it is stopped and replaced. Flutter.Error events from the '
+        'running app are automatically forwarded as MCP log warnings — no '
+        'polling needed.',
     inputSchema: Schema.object(
       properties: {
         'working_directory': Schema.string(
@@ -64,13 +59,13 @@ class RunAppTool extends InspectorTool {
     final String? device = args['device'] as String?;
     final String? target = args['target'] as String?;
 
-    final String sessionId = sessionIdGenerator();
+    final bool hadExisting = context.activeSession != null;
 
     final AppSession session;
     try {
       session = await AppSession.start(
         workingDirectory: workingDirectory,
-        eventListener: (event) => eventListener(sessionId, event),
+        eventListener: eventListener,
         deviceId: device,
         target: target,
         debugLog: (message) => context.log(LoggingLevel.info, message),
@@ -82,14 +77,13 @@ class RunAppTool extends InspectorTool {
       );
     }
 
-    registerSession(sessionId, session);
+    await registerSession(session);
 
     final String deviceInfo =
-        session.deviceId != null ? 'Device ID: ${session.deviceId}, ' : '';
+        session.deviceId != null ? ' Device: ${session.deviceId}.' : '';
+    final String replaced = hadExisting ? ' Previous app was stopped.' : '';
     return CallToolResult(
-      content: [
-        TextContent(text: 'Launched. ${deviceInfo}Session ID: $sessionId'),
-      ],
+      content: [TextContent(text: 'Launched.$deviceInfo$replaced')],
     );
   }
 }

--- a/lib/src/inspector/tools/take_screenshot_tool.dart
+++ b/lib/src/inspector/tools/take_screenshot_tool.dart
@@ -20,16 +20,13 @@ class TakeScreenshotTool extends InspectorTool {
         'not appear in the screenshot even if visible on screen.',
     inputSchema: Schema.object(
       properties: {
-        'session_id': Schema.string(
-          description: 'The session ID returned by run_app.',
-        ),
         'pixel_ratio': Schema.num(
           description:
               'Device pixel ratio for the screenshot. Higher values produce '
               'sharper images. Defaults to 1.0.',
         ),
       },
-      required: ['session_id'],
+      required: [],
     ),
   );
 
@@ -38,13 +35,8 @@ class TakeScreenshotTool extends InspectorTool {
     CallToolRequest request,
     ToolContext context,
   ) async {
-    context.validateParams(request, definition.inputSchema.required!);
-
-    final String sessionId = request.arguments!['session_id'] as String;
-    final session = context.session(sessionId);
-    if (session == null) {
-      return context.unknownSession(sessionId);
-    }
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
 
     final num? pixelRatioArg = request.arguments!['pixel_ratio'] as num?;
     final double? pixelRatio = pixelRatioArg?.toDouble();

--- a/test/inspector/inspector_mcp_test.dart
+++ b/test/inspector/inspector_mcp_test.dart
@@ -13,16 +13,13 @@ void main() {
       await env.initializeServer();
     });
 
-    test('returns an error for an unknown session ID', () async {
+    test('returns a message when no app is running', () async {
       final result = await env.serverConnection.callTool(
-        CallToolRequest(
-          name: 'close_app',
-          arguments: {'session_id': 'unknown'},
-        ),
+        CallToolRequest(name: 'close_app', arguments: {}),
       );
 
-      expect(result.isError, true);
-      expect((result.content.first as TextContent).text, contains('unknown'));
+      expect(result.isError, isNot(true));
+      expect((result.content.first as TextContent).text, 'No app was running.');
     });
   });
 }

--- a/tool/generate_docs.dart
+++ b/tool/generate_docs.dart
@@ -37,6 +37,20 @@ void main() async {
   docFile.writeAsStringSync(buf.toString());
 
   print('README.md, ${docFile.path} updated.');
+
+  // After generation, as a best effort, run the prettier npm tool.
+  // 'npx prettier --write docs/slipstream_doc.md README.md'
+  final result = Process.runSync('npx', [
+    'prettier',
+    '--write',
+    'docs/slipstream_doc.md',
+    'README.md',
+  ]);
+  print('npx prettier: ${result.exitCode}');
+  if (result.exitCode != 0) {
+    print(result.stdout);
+    print(result.stderr);
+  }
 }
 
 void writeServerDocs(

--- a/tool/inspector_integration_test.dart
+++ b/tool/inspector_integration_test.dart
@@ -27,20 +27,19 @@ void main(List<String> args) {
   }
 
   late TestEnvironment<TestMCPClient, InspectorMCPServer> env;
-  late String sessionId;
 
   setUpAll(() async {
     env = TestEnvironment(TestMCPClient(), InspectorMCPServer.new);
     await env.initializeServer();
 
     final String projectDir = Directory(args[0]).absolute.path;
-    sessionId = await _startApp(env, projectDir);
+    await _startApp(env, projectDir);
   });
 
   tearDownAll(() async {
     // TODO: Sombody else is closing the app for us...
     // await env.serverConnection.callTool(
-    //   CallToolRequest(name: 'close_app', arguments: {'session_id': sessionId}),
+    //   CallToolRequest(name: 'close_app'),
     // );
 
     await env.shutdown();
@@ -63,24 +62,11 @@ void main(List<String> args) {
   group('take_screenshot', () {
     test('returns a valid result', () async {
       final result = await env.serverConnection.callTool(
-        CallToolRequest(
-          name: 'take_screenshot',
-          arguments: {'session_id': sessionId},
-        ),
+        CallToolRequest(name: 'take_screenshot'),
       );
 
       expect(result.isError, isNull);
       expect(result.content.first, isA<ImageContent>());
-    });
-
-    test('returns error when required argument is missing', () async {
-      final result = await env.serverConnection.callTool(
-        CallToolRequest(name: 'take_screenshot', arguments: {}),
-      );
-
-      expect(result.isError, isTrue);
-      final text = (result.content.first as TextContent).text;
-      expect(text, contains('session_id'));
     });
   });
 
@@ -98,7 +84,6 @@ void main(List<String> args) {
 
       expect(result.isError, isTrue);
       final text = (result.content.first as TextContent).text;
-      expect(text, contains('session_id'));
       expect(text, contains('path'));
     });
   });
@@ -113,7 +98,6 @@ void main(List<String> args) {
 
       expect(result.isError, isTrue);
       final text = (result.content.first as TextContent).text;
-      expect(text, contains('session_id'));
       expect(text, contains('text'));
     });
   });
@@ -121,22 +105,9 @@ void main(List<String> args) {
   // todo: get_semantics
 
   group('close_app', () {
-    test('returns error when required argument is missing', () async {
-      final result = await env.serverConnection.callTool(
-        CallToolRequest(name: 'close_app', arguments: {}),
-      );
-
-      expect(result.isError, isTrue);
-      final text = (result.content.first as TextContent).text;
-      expect(text, contains('session_id'));
-    });
-
     test('closes the app', () async {
       final result = await env.serverConnection.callTool(
-        CallToolRequest(
-          name: 'close_app',
-          arguments: {'session_id': sessionId},
-        ),
+        CallToolRequest(name: 'close_app'),
       );
 
       expect(result.isError, isNull);
@@ -146,10 +117,11 @@ void main(List<String> args) {
   });
 }
 
-Future<String> _startApp(
+Future<void> _startApp(
   TestEnvironment<TestMCPClient, InspectorMCPServer> env,
   String projectDir,
 ) async {
+  // ignore: unused_local_variable
   final result = await env.serverConnection.callTool(
     CallToolRequest(
       name: 'run_app',
@@ -157,14 +129,8 @@ Future<String> _startApp(
     ),
   );
 
-  const token = 'Session ID:';
-
-  // "'Launched. Device ID: zzz, Session ID: yyy'"
-  final text = (result.content.first as TextContent).text;
-  final sessionId = text.substring(text.indexOf(token) + token.length).trim();
+  // "'Launched. (device ID: zzz)'"
 
   // No real reason for this (prevents flashing open and closed?).
   await Future.delayed(Duration(milliseconds: 500));
-
-  return sessionId;
 }

--- a/tool/inspector_integration_test.dart
+++ b/tool/inspector_integration_test.dart
@@ -103,14 +103,12 @@ void main(List<String> args) {
     });
   });
 
-  // todo: get_semantics
+  // todo: perform_tap
 
-  // todo: tap
-
-  group('set_text', () {
+  group('perform_set_text', () {
     test('returns error when required argument is missing', () async {
       final result = await env.serverConnection.callTool(
-        CallToolRequest(name: 'set_text', arguments: {}),
+        CallToolRequest(name: 'perform_set_text', arguments: {}),
       );
 
       expect(result.isError, isTrue);
@@ -119,6 +117,8 @@ void main(List<String> args) {
       expect(text, contains('text'));
     });
   });
+
+  // todo: get_semantics
 
   group('close_app', () {
     test('returns error when required argument is missing', () async {


### PR DESCRIPTION
Removes the `session_id` parameter from all inspector MCP tool calls. Only one app session is active at a time — `run_app` launches (or silently replaces) it, and all other tools use it automatically.

- `run_app` no longer returns a session ID; response is "Launched." (plus a note if a previous app was stopped)
- `close_app` takes no arguments; returns "Closed app." or "No app was running."
- All other tools drop `session_id` from their input schemas and return a clear "No app is currently running. Call run_app first." error when invoked without an active session
- Also fixes #67: `evaluate` now returns `''` instead of blank output for empty string results
- Also fixes #68: `perform_set_text` now fires the field's `onChanged` callback
- Fixes https://github.com/devoncarew/flutter-slipstream/issues/69
