### PR TITLE
resolve packages via package_config.json instead of pubspec.lock + pub cache

### DIFF
--- a/docs/slipstream_doc.md
+++ b/docs/slipstream_doc.md
@@ -34,8 +34,9 @@ The returned package summary contains version, entry-point import, README
 excerpt, public library list, and exported name groups for the main library.
 
 - `project_directory`: (required) Absolute path to the Dart/Flutter project
-  directory (the folder containing pubspec.yaml). Used to resolve the package
-  version from pubspec.lock and to locate the package_config.json for analysis.
+  directory (the folder containing pubspec.yaml). Used to locate
+  .dart_tool/package_config.json for package resolution and analysis. Run
+  `dart pub get` first if the config is missing.
 - `package`: (required) The package name (e.g. "http", "provider").
 
 ### `packages:library_stub`
@@ -48,8 +49,9 @@ Returns the full public API for one library as a Dart stub (signatures only, no
 bodies).
 
 - `project_directory`: (required) Absolute path to the Dart/Flutter project
-  directory (the folder containing pubspec.yaml). Used to resolve the package
-  version from pubspec.lock and to locate the package_config.json for analysis.
+  directory (the folder containing pubspec.yaml). Used to locate
+  .dart_tool/package_config.json for package resolution and analysis. Run
+  `dart pub get` first if the config is missing.
 - `package`: (required) The package name (e.g. "http", "provider").
 - `library_uri`: (required) The library URI to target, e.g.
   "package:http/http.dart".
@@ -64,8 +66,9 @@ Returns the public API for a single named class, mixin, or extension as a Dart
 stub (signatures only, no bodies).
 
 - `project_directory`: (required) Absolute path to the Dart/Flutter project
-  directory (the folder containing pubspec.yaml). Used to resolve the package
-  version from pubspec.lock and to locate the package_config.json for analysis.
+  directory (the folder containing pubspec.yaml). Used to locate
+  .dart_tool/package_config.json for package resolution and analysis. Run
+  `dart pub get` first if the config is missing.
 - `package`: (required) The package name (e.g. "http", "provider").
 - `library_uri`: (required) The library URI to target, e.g.
   "package:http/http.dart".

--- a/lib/src/shorthand/context.dart
+++ b/lib/src/shorthand/context.dart
@@ -1,8 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_mcp/server.dart';
 import 'package:path/path.dart' as path;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 import '../common.dart';
@@ -32,29 +32,18 @@ class ToolContext {
     }
   }
 
-  /// Resolves the version used by the project and finds the package and version
-  /// in the pub cache.
+  /// Resolves the directory for [packageName] using the project's
+  /// `.dart_tool/package_config.json`.
   ///
-  /// This will throw a [ToolException] if the package is not found.
-  Directory findPackageInPubCache(String projectDirectory, String packageName) {
-    // Resolve version: pubspec.lock → latest cached.
-    final String? version = resolveVersionFromLockfile(
-      projectDirectory,
-      packageName,
+  /// Throws a [ToolException] if the package is not found.
+  Directory resolvePackage(String projectDirectory, String packageName) {
+    final packageDir = resolvePackageFromConfig(projectDirectory, packageName);
+    if (packageDir != null) return packageDir;
+
+    throw ToolException(
+      "Package '$packageName' not found. Make sure it is listed in "
+      'pubspec.yaml and run `dart pub get`.',
     );
-    final Directory? packageDir = locateInPubCache(packageName, version);
-
-    if (packageDir == null) {
-      final message =
-          version != null
-              ? "Package '$packageName' version $version not found in pub "
-                  'cache. Run `dart pub get` to download it.'
-              : "Package '$packageName' not found in pub cache. Add it to "
-                  'pubspec.yaml and run `dart pub get`.';
-      throw ToolException(message);
-    }
-
-    return packageDir;
   }
 
   String? findPackageConfig(String projectDirectory) {
@@ -89,8 +78,9 @@ class ToolContext {
 final StringSchema projectDirectorySchema = Schema.string(
   description:
       'Absolute path to the Dart/Flutter project directory (the folder '
-      'containing pubspec.yaml). Used to resolve the package version from '
-      'pubspec.lock and to locate the package_config.json for analysis.',
+      'containing pubspec.yaml). Used to locate '
+      '.dart_tool/package_config.json for package resolution and analysis. '
+      'Run `dart pub get` first if the config is missing.',
 );
 
 final StringSchema packageSchema = Schema.string(
@@ -104,28 +94,55 @@ final StringSchema librarySchema = Schema.string(
 // ---------------------------------------------------------------------------
 // Package resolution helpers (top-level functions for testability)
 
-/// Returns the resolved version for [packageName] from the nearest
-/// `pubspec.lock` found by walking up from [projectDirectory].
+/// Resolves the directory for [packageName] from the nearest
+/// `.dart_tool/package_config.json` found by walking up from
+/// [projectDirectory].
 ///
-/// Walking up correctly handles pub workspaces where the lock file lives at
-/// the workspace root rather than in each member package's directory.
-/// Returns null if no lock file is found or the package is not listed.
-String? resolveVersionFromLockfile(
+/// The `rootUri` in the config may be an absolute `file://` URI (hosted, git,
+/// and SDK packages such as `package:flutter`) or a relative URI (path
+/// dependencies). Relative URIs are resolved against the `.dart_tool/`
+/// directory that contains the config file.
+///
+/// Walking up correctly handles pub workspaces where the config lives at the
+/// workspace root rather than in each member package's directory.
+///
+/// Returns null if no config file is found, the package is not listed, or the
+/// resolved directory does not exist on disk.
+Directory? resolvePackageFromConfig(
   String projectDirectory,
   String packageName,
 ) {
   var dir = Directory(projectDirectory);
   while (true) {
-    final lockFile = File(path.join(dir.path, 'pubspec.lock'));
-    if (lockFile.existsSync()) {
+    final configFile = File(
+      path.join(dir.path, '.dart_tool', 'package_config.json'),
+    );
+    if (configFile.existsSync()) {
       try {
-        final yaml = loadYaml(lockFile.readAsStringSync());
-        if (yaml is! Map) return null;
-        final packages = yaml['packages'];
-        if (packages is! Map) return null;
-        final entry = packages[packageName];
-        if (entry is! Map) return null;
-        return entry['version'] as String?;
+        final json =
+            jsonDecode(configFile.readAsStringSync()) as Map<String, dynamic>;
+        final packages =
+            (json['packages'] as List?)
+                ?.whereType<Map<String, dynamic>>()
+                .toList();
+        if (packages == null) return null;
+        for (final pkg in packages) {
+          if (pkg['name'] != packageName) continue;
+          final rootUri = pkg['rootUri'] as String?;
+          if (rootUri == null) return null;
+          final uri = Uri.parse(rootUri);
+          final Directory packageDir;
+          if (uri.isAbsolute) {
+            packageDir = Directory.fromUri(uri);
+          } else {
+            // Relative URI — resolve against the .dart_tool directory.
+            packageDir = Directory.fromUri(
+              configFile.parent.uri.resolveUri(uri),
+            );
+          }
+          return packageDir.existsSync() ? packageDir : null;
+        }
+        return null; // package not listed in config
       } catch (_) {
         return null;
       }
@@ -135,53 +152,6 @@ String? resolveVersionFromLockfile(
     dir = parent;
   }
   return null;
-}
-
-/// Finds the package directory in the pub cache for [packageName].
-///
-/// If [version] is provided, looks for an exact match. Otherwise returns
-/// the directory with the highest semver version.
-/// Returns null if the pub cache cannot be located or the package is absent.
-Directory? locateInPubCache(String packageName, String? version) {
-  final pubCacheDir = pubCacheHostedDir();
-  if (pubCacheDir == null) return null;
-
-  if (version != null) {
-    final dir = Directory(path.join(pubCacheDir, '$packageName-$version'));
-    return dir.existsSync() ? dir : null;
-  }
-
-  // No version pinned — find the highest cached version.
-  final dirs =
-      Directory(pubCacheDir)
-          .listSync()
-          .whereType<Directory>()
-          .where((d) => path.basename(d.path).startsWith('$packageName-'))
-          .toList();
-  if (dirs.isEmpty) return null;
-
-  Version parseDir(Directory d) {
-    final suffix = path.basename(d.path).substring('$packageName-'.length);
-    try {
-      return Version.parse(suffix);
-    } catch (_) {
-      return Version.none;
-    }
-  }
-
-  dirs.sort((a, b) => parseDir(a).compareTo(parseDir(b)));
-  return dirs.last;
-}
-
-/// Returns the path to `~/.pub-cache/hosted/pub.dev`, or null if not found.
-///
-/// Respects the `PUB_CACHE` environment variable when set.
-String? pubCacheHostedDir() {
-  final pubCache =
-      Platform.environment['PUB_CACHE'] ??
-      path.join(Platform.environment['HOME'] ?? '', '.pub-cache');
-  final hosted = path.join(pubCache, 'hosted', 'pub.dev');
-  return Directory(hosted).existsSync() ? hosted : null;
 }
 
 /// Reads the `version` field from a package's own `pubspec.yaml`.

--- a/lib/src/shorthand/tools/class_stub_tool.dart
+++ b/lib/src/shorthand/tools/class_stub_tool.dart
@@ -42,10 +42,7 @@ class ClassStubTool extends PackagesTool {
     final String libraryUri = request.arguments?['library_uri'] as String;
     final String className = request.arguments?['class'] as String;
 
-    final packageDir = context.findPackageInPubCache(
-      projectDirectory,
-      packageName,
-    );
+    final packageDir = context.resolvePackage(projectDirectory, packageName);
 
     return _handleClassStub(
       context,

--- a/lib/src/shorthand/tools/library_stub_tool.dart
+++ b/lib/src/shorthand/tools/library_stub_tool.dart
@@ -37,10 +37,7 @@ class LibraryStubTool extends PackagesTool {
     final String packageName = request.arguments?['package'] as String;
     final String libraryUri = request.arguments?['library_uri'] as String;
 
-    final packageDir = context.findPackageInPubCache(
-      projectDirectory,
-      packageName,
-    );
+    final packageDir = context.resolvePackage(projectDirectory, packageName);
 
     return _handleLibraryStub(
       context,

--- a/lib/src/shorthand/tools/package_summary_tool.dart
+++ b/lib/src/shorthand/tools/package_summary_tool.dart
@@ -45,7 +45,7 @@ class PackageSummaryTool extends PackagesTool {
 
     final packageDir = context.resolvePackage(projectDirectory, packageName);
 
-    final version = readPackageVersion(packageDir) ?? 'unknown';
+    final version = readPackageVersion(packageDir);
 
     return _handlePackageSummary(
       context,
@@ -60,13 +60,14 @@ class PackageSummaryTool extends PackagesTool {
     ToolContext context, {
     required String packageName,
     required Directory packageDir,
-    required String resolvedVersion,
+    required String? resolvedVersion,
     required String projectDirectory,
   }) async {
     final buf = StringBuffer();
 
     // Header.
-    buf.writeln('Package: $packageName $resolvedVersion');
+    final versionDesc = resolvedVersion == null ? '' : ' ($resolvedVersion)';
+    buf.writeln('Package: $packageName$versionDesc');
     buf.writeln('Source: ${packageDir.path}');
 
     // Entry-point import — only if the conventional lib/name.dart exists.

--- a/lib/src/shorthand/tools/package_summary_tool.dart
+++ b/lib/src/shorthand/tools/package_summary_tool.dart
@@ -43,10 +43,7 @@ class PackageSummaryTool extends PackagesTool {
         request.arguments?['project_directory'] as String;
     final String packageName = request.arguments?['package'] as String;
 
-    final packageDir = context.findPackageInPubCache(
-      projectDirectory,
-      packageName,
-    );
+    final packageDir = context.resolvePackage(projectDirectory, packageName);
 
     final version = readPackageVersion(packageDir) ?? 'unknown';
 

--- a/test/shorthand/package_info_test.dart
+++ b/test/shorthand/package_info_test.dart
@@ -1,82 +1,46 @@
+import 'dart:io';
+
 import 'package:flutter_slipstream/src/shorthand/context.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-// The project root — where pubspec.yaml and pubspec.lock live.
+// The project root — where pubspec.yaml and .dart_tool/ live.
 // Tests run from the package root, so '.' is correct.
-const String projectDir = '.';
+final String projectDir = Directory.current.absolute.path;
 
 void main() {
-  group('resolveVersionFromLockfile', () {
-    test('resolves a known direct dependency', () {
-      // http is a direct dependency of this project.
-      final version = resolveVersionFromLockfile(projectDir, 'http');
-      expect(version, isNotNull);
-      // Should be a valid semver string.
-      expect(version, matches(RegExp(r'^\d+\.\d+\.\d+')));
+  group('resolvePackageFromConfig', () {
+    test('resolves a hosted dependency', () {
+      final dir = resolvePackageFromConfig(projectDir, 'http');
+      expect(dir, isNotNull);
+      expect(dir!.existsSync(), isTrue);
     });
 
     test('resolves a transitive dependency', () {
-      // yaml is a direct dependency; http_parser is transitive via http.
-      final version = resolveVersionFromLockfile(projectDir, 'http_parser');
-      expect(version, isNotNull);
-    });
-
-    test('returns null for an unknown package', () {
-      final version = resolveVersionFromLockfile(
-        projectDir,
-        'no_such_package_xyz',
-      );
-      expect(version, isNull);
-    });
-
-    test('walks up to find lock file from a subdirectory', () {
-      // Starting inside lib/ should still find the root pubspec.lock.
-      final version = resolveVersionFromLockfile('$projectDir/lib', 'http');
-      expect(version, isNotNull);
-    });
-  });
-
-  group('pubCacheHostedDir', () {
-    test('returns a non-null path that exists on disk', () {
-      final dir = pubCacheHostedDir();
-      expect(dir, isNotNull);
-    });
-  });
-
-  group('findPackageInPubCache', () {
-    test('finds http at the version in pubspec.lock', () {
-      final version = resolveVersionFromLockfile(projectDir, 'http');
-      expect(version, isNotNull);
-      final dir = locateInPubCache('http', version);
-      expect(dir, isNotNull);
-      expect(dir!.existsSync(), isTrue);
-    });
-
-    test('finds http with no version — returns highest cached', () {
-      final dir = locateInPubCache('http', null);
+      final dir = resolvePackageFromConfig(projectDir, 'http_parser');
       expect(dir, isNotNull);
       expect(dir!.existsSync(), isTrue);
     });
 
     test('returns null for an unknown package', () {
-      final dir = locateInPubCache('no_such_package_xyz', null);
+      final dir = resolvePackageFromConfig(projectDir, 'no_such_package_xyz');
       expect(dir, isNull);
     });
 
-    test('returns null for a known package at a non-existent version', () {
-      final dir = locateInPubCache('http', '0.0.0-nonexistent');
-      expect(dir, isNull);
+    test('walks up to find config from a subdirectory', () {
+      final dir = resolvePackageFromConfig(p.join(projectDir, 'lib'), 'http');
+      expect(dir, isNotNull);
+      expect(dir!.existsSync(), isTrue);
     });
   });
 
   group('readPackageVersion', () {
-    test('reads the version of a cached package', () {
-      final lockVersion = resolveVersionFromLockfile(projectDir, 'http');
-      expect(lockVersion, isNotNull);
-      final dir = locateInPubCache('http', lockVersion);
+    test('reads the version of a resolved package', () {
+      final dir = resolvePackageFromConfig(projectDir, 'http');
       expect(dir, isNotNull);
       final version = readPackageVersion(dir!);
-      expect(version, lockVersion);
+      expect(version, isNotNull);
+      expect(version, matches(RegExp(r'^\d+\.\d+\.\d+')));
     });
   });
 }

--- a/test/shorthand/resolver_test.dart
+++ b/test/shorthand/resolver_test.dart
@@ -10,9 +10,9 @@ import 'package:test/test.dart';
 final String projectDir = Directory.current.absolute.path;
 
 PackageResolver resolverFor(String packageName) {
-  final version = resolveVersionFromLockfile(packageName, projectDir);
-  final packageDir = locateInPubCache(packageName, version);
-  if (packageDir == null) throw StateError('$packageName not in pub cache');
+  final packageDir = resolvePackageFromConfig(projectDir, packageName);
+  if (packageDir == null)
+    throw StateError('$packageName not in package config');
   final packageConfigFile = p.join(
     projectDir,
     '.dart_tool',

--- a/test/shorthand/resolver_test.dart
+++ b/test/shorthand/resolver_test.dart
@@ -11,8 +11,9 @@ final String projectDir = Directory.current.absolute.path;
 
 PackageResolver resolverFor(String packageName) {
   final packageDir = resolvePackageFromConfig(projectDir, packageName);
-  if (packageDir == null)
+  if (packageDir == null) {
     throw StateError('$packageName not in package config');
+  }
   final packageConfigFile = p.join(
     projectDir,
     '.dart_tool',

--- a/test/shorthand/stub_emitter_test.dart
+++ b/test/shorthand/stub_emitter_test.dart
@@ -9,9 +9,9 @@ import 'package:test/test.dart';
 final String projectDir = Directory.current.absolute.path;
 
 PackageResolver resolverFor(String packageName) {
-  final version = resolveVersionFromLockfile(packageName, projectDir);
-  final packageDir = locateInPubCache(packageName, version);
-  if (packageDir == null) throw StateError('$packageName not in pub cache');
+  final packageDir = resolvePackageFromConfig(projectDir, packageName);
+  if (packageDir == null)
+    throw StateError('$packageName not in package config');
   return PackageResolver(
     packageDir: packageDir,
     packageConfigFile: p.join(projectDir, '.dart_tool', 'package_config.json'),

--- a/test/shorthand/stub_emitter_test.dart
+++ b/test/shorthand/stub_emitter_test.dart
@@ -10,8 +10,9 @@ final String projectDir = Directory.current.absolute.path;
 
 PackageResolver resolverFor(String packageName) {
   final packageDir = resolvePackageFromConfig(projectDir, packageName);
-  if (packageDir == null)
+  if (packageDir == null) {
     throw StateError('$packageName not in package config');
+  }
   return PackageResolver(
     packageDir: packageDir,
     packageConfigFile: p.join(projectDir, '.dart_tool', 'package_config.json'),


### PR DESCRIPTION
Resolve packages via package_config.json instead of pubspec.lock + pub cache:

- Replaces the pubspec.lock → pub-cache lookup with a direct read of .dart_tool/package_config.json. The rootUri field covers all package sources — hosted, path, git, and SDK packages like package:flutter — so no special-casing is needed.
- Removes resolveVersionFromLockfile, locateInPubCache, and pubCacheHostedDir.
- Fixes https://github.com/devoncarew/flutter-slipstream/issues/66.
