### PR TITLE
Add companion event forwarding and get_semantics integration

### DIFF
--- a/lib/src/inspector/app_session.dart
+++ b/lib/src/inspector/app_session.dart
@@ -355,9 +355,7 @@ class AppSession {
     if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
       // Convert regular stdio output to log messages.
       if (!_sessionEnded) {
-        _eventListener(
-          DaemonEvent('app.log', {'appId': _appId, 'log': trimmed}),
-        );
+        _eventListener(AppEvent('app.log', {'appId': _appId, 'log': trimmed}));
       }
       return;
     }
@@ -414,7 +412,7 @@ class AppSession {
       }
 
       if (!_sessionEnded) {
-        _eventListener(DaemonEvent(event, params));
+        _eventListener(AppEvent(event, params));
       }
     }
   }
@@ -446,9 +444,7 @@ class AppSession {
             }
             _errors.add(error);
             _eventListener(
-              DaemonEvent('flutter.error', {
-                'summary': compactSummarizer(error),
-              }),
+              AppEvent('flutter.error', {'summary': compactSummarizer(error)}),
             );
           }
         }
@@ -458,10 +454,15 @@ class AppSession {
         final description =
             route is Map ? route['description'] as String? : null;
         _eventListener(
-          DaemonEvent('flutter.navigation', {
+          AppEvent('flutter.navigation', {
             if (description != null) 'route': description,
           }),
         );
+      } else if (event.extensionKind == 'ext.slipstream.windowResized') {
+        final data = event.extensionData?.data;
+        if (data != null) {
+          _eventListener(AppEvent('slipstream.windowResized', Map.of(data)));
+        }
       } else if (event.extensionKind == 'Flutter.FrameworkInitialization') {
         // This happens early after a full restart.
       } else if (event.extensionKind == 'Flutter.FirstFrame') {
@@ -497,7 +498,7 @@ class AppSession {
     // If the app was running and we didn't initiate the stop ourselves,
     // emit a synthetic app.stop so the server can clean up the session.
     if (!_sessionEnded && _appId != null) {
-      _eventListener(DaemonEvent('app.stop', {'appId': _appId}));
+      _eventListener(AppEvent('app.stop', {'appId': _appId}));
     }
 
     _sessionEnded = true;
@@ -509,13 +510,15 @@ class AppSession {
   }
 }
 
-/// An event emitted by a running Flutter app via the `flutter run --machine`
-/// daemon protocol.
-class DaemonEvent {
+/// An event emitted by the running Flutter app.
+///
+/// These are either events directly from the `flutter run --machine` daemon
+/// protocol or semantic events from the VM service protocol.
+class AppEvent {
   final String event;
   final Map<String, dynamic> params;
 
-  DaemonEvent(this.event, this.params);
+  AppEvent(this.event, this.params);
 }
 
 /// An error returned from a command sent to 'flutter run' over the daemon
@@ -581,4 +584,4 @@ class FlutterError {
   String toString() => 'FlutterError: $summary';
 }
 
-typedef EventCallback = void Function(DaemonEvent);
+typedef EventCallback = void Function(AppEvent);

--- a/lib/src/inspector/app_session.dart
+++ b/lib/src/inspector/app_session.dart
@@ -448,16 +448,12 @@ class AppSession {
             );
           }
         }
-      } else if (event.extensionKind == 'Flutter.Navigation') {
+      } else if (event.extensionKind == 'ext.slipstream.routeChanged') {
         final data = event.extensionData?.data;
-        final route = data?['route'];
-        final description =
-            route is Map ? route['description'] as String? : null;
-        _eventListener(
-          AppEvent('flutter.navigation', {
-            if (description != null) 'route': description,
-          }),
-        );
+        final String? path = data?['path'] as String?;
+        if (path != null) {
+          _eventListener(AppEvent('slipstream.routeChanged', {'path': path}));
+        }
       } else if (event.extensionKind == 'ext.slipstream.windowResized') {
         final data = event.extensionData?.data;
         if (data != null) {

--- a/lib/src/inspector/flutter_service_extensions.dart
+++ b/lib/src/inspector/flutter_service_extensions.dart
@@ -38,19 +38,7 @@ class FlutterServiceExtensions {
   }
 
   // ---------------------------------------------------------------------------
-  // ext.slipstream.* — companion package detection
-
-  /// Calls a `ext.slipstream.*` extension and returns the response JSON.
-  ///
-  /// The caller is responsible for checking `response['ok']` and handling
-  /// `response['error']`. Throws an [RPCError] on VM service failures.
-  Future<Map<String, dynamic>> callSlipstreamExtension(
-    String method, {
-    Map<String, dynamic>? args,
-  }) async {
-    final response = await _callExtension(method, args: args);
-    return (response.json ?? {}).cast<String, dynamic>();
-  }
+  // ext.slipstream.* — companion package
 
   /// Calls `ext.slipstream.ping` to detect the slipstream_agent companion
   /// package.
@@ -66,6 +54,137 @@ class FlutterServiceExtensions {
       // Extension not registered — companion not installed. Fail open.
       return null;
     }
+  }
+
+  /// Calls `ext.slipstream.perform_action` to tap a widget located by
+  /// [finder]/[finderValue].
+  ///
+  /// Returns `(ok: true)` on success or `(ok: false, error: '...')` on failure.
+  Future<({bool ok, String? error})> slipstreamTap({
+    required String finder,
+    required String finderValue,
+  }) => _slipstreamAction({
+    'action': 'tap',
+    'finder': finder,
+    'finderValue': finderValue,
+  });
+
+  /// Calls `ext.slipstream.perform_action` to set text on a widget located by
+  /// [finder]/[finderValue].
+  ///
+  /// Returns `(ok: true)` on success or `(ok: false, error: '...')` on failure.
+  Future<({bool ok, String? error})> slipstreamSetText({
+    required String finder,
+    required String finderValue,
+    required String text,
+  }) => _slipstreamAction({
+    'action': 'set_text',
+    'finder': finder,
+    'finderValue': finderValue,
+    'text': text,
+  });
+
+  /// Calls `ext.slipstream.perform_action` to scroll a [Scrollable] widget
+  /// located by [finder]/[finderValue] by [pixels] logical pixels in
+  /// [direction].
+  ///
+  /// Returns `(ok: true)` on success or `(ok: false, error: '...')` on failure.
+  Future<({bool ok, String? error})> slipstreamScroll({
+    required String finder,
+    required String finderValue,
+    required String direction,
+    required String pixels,
+  }) => _slipstreamAction({
+    'action': 'scroll',
+    'finder': finder,
+    'finderValue': finderValue,
+    'direction': direction,
+    'pixels': pixels,
+  });
+
+  /// Calls `ext.slipstream.perform_action` to scroll the [Scrollable] located
+  /// by [scrollFinder]/[scrollFinderValue] until the widget located by
+  /// [finder]/[finderValue] is visible.
+  ///
+  /// Returns `(ok: true)` on success or `(ok: false, error: '...')` on failure.
+  Future<({bool ok, String? error})> slipstreamScrollUntilVisible({
+    required String finder,
+    required String finderValue,
+    required String scrollFinder,
+    required String scrollFinderValue,
+  }) => _slipstreamAction({
+    'action': 'scroll_until_visible',
+    'finder': finder,
+    'finderValue': finderValue,
+    'scrollFinder': scrollFinder,
+    'scrollFinderValue': scrollFinderValue,
+  });
+
+  Future<({bool ok, String? error})> _slipstreamAction(
+    Map<String, dynamic> args,
+  ) async {
+    final response = await _callExtension(
+      'ext.slipstream.perform_action',
+      args: args,
+    );
+    final json = (response.json ?? {}).cast<String, dynamic>();
+    return (ok: json['ok'] as bool? ?? false, error: json['error'] as String?);
+  }
+
+  /// Calls `ext.slipstream.navigate` to navigate the app to [path] via the
+  /// registered router adapter.
+  ///
+  /// Returns `(ok: true)` on success or `(ok: false, error: '...')` on failure.
+  Future<({bool ok, String? error})> slipstreamNavigate(String path) async {
+    final response = await _callExtension(
+      'ext.slipstream.navigate',
+      args: {'path': path},
+    );
+    final json = (response.json ?? {}).cast<String, dynamic>();
+    return (ok: json['ok'] as bool? ?? false, error: json['error'] as String?);
+  }
+
+  /// Calls `ext.slipstream.get_route` to get the current route path from the
+  /// registered router adapter.
+  ///
+  /// Returns `(ok: true, path: '/...')` on success or
+  /// `(ok: false, error: '...')` on failure.
+  Future<({bool ok, String? path, String? error})> slipstreamGetRoute() async {
+    final response = await _callExtension('ext.slipstream.get_route');
+    final json = (response.json ?? {}).cast<String, dynamic>();
+    return (
+      ok: json['ok'] as bool? ?? false,
+      path: json['path'] as String?,
+      error: json['error'] as String?,
+    );
+  }
+
+  /// Calls `ext.slipstream.enable_semantics` to enable the Flutter semantics
+  /// tree and schedule a frame so the tree is populated.
+  Future<void> slipstreamEnableSemantics() async {
+    await _callExtension('ext.slipstream.enable_semantics');
+  }
+
+  /// Calls `ext.slipstream.get_semantics` to get a flat list of visible
+  /// semantics nodes with screen-space coordinates.
+  ///
+  /// Returns `(ok: true, nodes: [...])` on success or
+  /// `(ok: false, error: '...')` on failure (e.g. semantics not enabled).
+  Future<({bool ok, List<SemanticNode> nodes, String? error})>
+  slipstreamGetSemantics() async {
+    final response = await _callExtension('ext.slipstream.get_semantics');
+    final json = (response.json ?? {}).cast<String, dynamic>();
+    final bool ok = json['ok'] as bool? ?? false;
+    return (
+      ok: ok,
+      nodes:
+          ok
+              ? parseCompanionSemanticsNodes(
+                json['nodes'] as List<dynamic>? ?? [],
+              )
+              : const <SemanticNode>[],
+      error: json['error'] as String?,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/inspector/inspector_mcp.dart
+++ b/lib/src/inspector/inspector_mcp.dart
@@ -124,13 +124,25 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
     await super.shutdown();
   }
 
-  void _handleEvent(DaemonEvent event) {
+  void _handleEvent(AppEvent event) {
     if (event.event == 'app.stop') {
       _context.removeSession();
 
       log(
         LoggingLevel.info,
         'App stopped; session released.',
+        logger: _loggerId,
+      );
+      return;
+    } else if (event.event == 'slipstream.windowResized') {
+      final p = event.params;
+      final double w = (p['logicalWidth'] as num?)?.toDouble() ?? 0;
+      final double h = (p['logicalHeight'] as num?)?.toDouble() ?? 0;
+      final double dpr = (p['devicePixelRatio'] as num?)?.toDouble() ?? 1;
+      log(
+        LoggingLevel.info,
+        '[window] ${w.toStringAsFixed(0)}×${h.toStringAsFixed(0)} logical px '
+        '(dpr=${dpr.toStringAsFixed(1)})',
         logger: _loggerId,
       );
       return;
@@ -172,7 +184,7 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
     }
   }
 
-  (LoggingLevel, String)? _convertToLog(DaemonEvent event) {
+  (LoggingLevel, String)? _convertToLog(AppEvent event) {
     final Map<String, dynamic> params = event.params;
 
     String message = params.keys

--- a/lib/src/inspector/inspector_mcp.dart
+++ b/lib/src/inspector/inspector_mcp.dart
@@ -146,25 +146,14 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
         logger: _loggerId,
       );
       return;
+    } else if (event.event == 'slipstream.routeChanged') {
+      final String path = event.params['path'] as String? ?? '?';
+      log(LoggingLevel.info, '[route] $path', logger: _loggerId);
+      return;
     } else if (event.event == 'flutter.error') {
       final String summary =
           event.params['summary'] as String? ?? 'Unknown Flutter error';
       log(LoggingLevel.warning, '[flutter.error] $summary', logger: _loggerId);
-      return;
-    } else if (event.event == 'flutter.navigation') {
-      // The Flutter.Navigation event is only emitted by the imperative
-      // Navigator API (push/pop/replace). go_router's context.go() works
-      // declaratively (rebuilds the stack), so navigation events fire on
-      // back-navigation (pop) but not on forward navigation (go()).
-      //
-      // Sample go_router pop event description (path template, not path):
-      //   _PageBasedMaterialPageRoute<void>(/podcast/:id)
-      final routeDesc = event.params['route'];
-      log(
-        LoggingLevel.info,
-        '[flutter.navigation] $routeDesc (use get_route to see current stack)',
-        logger: _loggerId,
-      );
       return;
     }
 

--- a/lib/src/inspector/semantic_node.dart
+++ b/lib/src/inspector/semantic_node.dart
@@ -23,6 +23,7 @@ class SemanticNode {
     required this.top,
     required this.right,
     required this.bottom,
+    this.hasScreenSpaceCoords = false,
   });
 
   /// Framework-internal integer ID. Root node is always 0.
@@ -72,12 +73,18 @@ class SemanticNode {
   /// - focus=1<<22.
   final int actions;
 
-  /// Bounding box in the node's local coordinate space.
-  /// The root node's local space is screen coordinates.
+  /// Bounding box coordinates. When [hasScreenSpaceCoords] is true, these are
+  /// accumulated screen-space coordinates (from the companion package). When
+  /// false, they are local coordinate space (only reliable for the root node).
   final double left;
   final double top;
   final double right;
   final double bottom;
+
+  /// Whether [left]/[top]/[right]/[bottom] are in screen space. True when the
+  /// data came from `ext.slipstream.get_semantics` (companion), which
+  /// accumulates transforms. False for the evaluate-based fallback path.
+  final bool hasScreenSpaceCoords;
 
   /// Whether the node supports a tap action.
   bool get supportsTap => actions & 1 != 0;
@@ -119,6 +126,44 @@ class SemanticNode {
 List<SemanticNode> parseSemanticsTree(String json) {
   final List<dynamic> raw = jsonDecode(json) as List<dynamic>;
   return raw.map((e) => _nodeFromTuple(e as List<dynamic>)).toList();
+}
+
+/// Parses the `nodes` array from an `ext.slipstream.get_semantics` response
+/// into a flat list of [SemanticNode]s.
+///
+/// Each element in [nodes] is an object:
+/// ```json
+/// { "id": 7, "role": "button", "label": "...", "value": "", "hint": "",
+///   "checked": null, "toggled": null, "selected": null, "enabled": null,
+///   "focused": false, "actions": 4194305,
+///   "left": 16.0, "top": 200.0, "right": 377.0, "bottom": 272.0 }
+/// ```
+///
+/// Coordinates are in screen space (accumulated transforms), unlike the
+/// tuple-based format where coordinates are in local space.
+List<SemanticNode> parseCompanionSemanticsNodes(List<dynamic> nodes) {
+  return nodes.map((e) => _nodeFromMap(e as Map<String, dynamic>)).toList();
+}
+
+SemanticNode _nodeFromMap(Map<String, dynamic> m) {
+  return SemanticNode(
+    id: m['id'] as int,
+    role: m['role'] as String? ?? '',
+    label: m['label'] as String? ?? '',
+    value: m['value'] as String? ?? '',
+    hint: m['hint'] as String? ?? '',
+    checked: m['checked'] as bool?,
+    toggled: m['toggled'] as bool?,
+    selected: m['selected'] as bool?,
+    enabled: m['enabled'] as bool?,
+    focused: m['focused'] as bool? ?? false,
+    actions: m['actions'] as int? ?? 0,
+    left: (m['left'] as num?)?.toDouble() ?? 0,
+    top: (m['top'] as num?)?.toDouble() ?? 0,
+    right: (m['right'] as num?)?.toDouble() ?? 0,
+    bottom: (m['bottom'] as num?)?.toDouble() ?? 0,
+    hasScreenSpaceCoords: true,
+  );
 }
 
 SemanticNode _nodeFromTuple(List<dynamic> t) {

--- a/lib/src/inspector/semantics_formatter.dart
+++ b/lib/src/inspector/semantics_formatter.dart
@@ -44,17 +44,30 @@ String _formatNode(SemanticNode node) {
   final role = node.role.isNotEmpty ? node.role : 'text';
   buf.writeln('[$role id=${node.id}$statesStr$actionsStr]');
 
-  if (node.label.isNotEmpty) buf.writeln('  label: "${_trunc(node.label)}"');
+  if (node.label.isNotEmpty) {
+    buf.writeln('  label: "${_trunc(_newlines(node.label))}"');
+  }
   if (node.hint.isNotEmpty) buf.writeln('  hint: ${node.hint}');
-  if (node.value.isNotEmpty) buf.writeln('  value: ${_trunc(node.value)}');
+  if (node.value.isNotEmpty) {
+    buf.writeln('  value: ${_trunc(_newlines(node.value))}');
+  }
 
-  // Size only — position is in local coordinate space, not screen space.
   final width = node.right - node.left;
   final height = node.bottom - node.top;
-  buf.writeln('  size: ${_fmt(width)}x${_fmt(height)}');
+  if (node.hasScreenSpaceCoords) {
+    buf.writeln(
+      '  position: ${_fmt(node.left)},${_fmt(node.top)} ${_fmt(width)}x${_fmt(height)}',
+    );
+  } else {
+    // Position is in local coordinate space and unreliable without
+    // accumulating parent transforms — show size only.
+    buf.writeln('  size: ${_fmt(width)}x${_fmt(height)}');
+  }
 
   return buf.toString();
 }
+
+String _newlines(String s) => s.replaceAll('\n', r'\n');
 
 String _trunc(String s, [int max = 100]) =>
     s.length > max ? '${s.substring(0, max - 1)}…' : s;

--- a/lib/src/inspector/tools/get_route_tool.dart
+++ b/lib/src/inspector/tools/get_route_tool.dart
@@ -41,12 +41,8 @@ class GetRouteTool extends InspectorTool {
       String? currentPath;
       if (session.hasCompanion) {
         try {
-          final response = await extensions.callSlipstreamExtension(
-            'ext.slipstream.get_route',
-          );
-          if (response['ok'] == true) {
-            currentPath = response['path'] as String?;
-          }
+          final result = await extensions.slipstreamGetRoute();
+          if (result.ok) currentPath = result.path;
         } catch (_) {
           // Path enrichment is best-effort — proceed without it.
         }

--- a/lib/src/inspector/tools/get_semantics_tool.dart
+++ b/lib/src/inspector/tools/get_semantics_tool.dart
@@ -24,6 +24,9 @@ class GetSemanticsTool extends InspectorTool {
     inputSchema: Schema.object(properties: {}, required: []),
   );
 
+  // TODO: Implement typed wrappers for the slipstream agent ext. methods in
+  // FlutterServiceExtensions.
+
   @override
   Future<CallToolResult> handle(
     CallToolRequest request,
@@ -33,8 +36,31 @@ class GetSemanticsTool extends InspectorTool {
     if (session == null) return context.noActiveSession();
 
     try {
-      final List<SemanticNode> nodes =
-          await session.serviceExtensions!.getSemanticsTree();
+      final List<SemanticNode> nodes;
+
+      if (session.hasCompanion) {
+        // Use the companion extension — returns screen-space coordinates.
+        final extensions = session.serviceExtensions!;
+
+        var response = await extensions.callSlipstreamExtension(
+          'ext.slipstream.get_semantics',
+        );
+
+        if (response['ok'] != true) {
+          final error = response['error'] as String? ?? 'get_semantics failed';
+          return CallToolResult(
+            content: [TextContent(text: error)],
+            isError: true,
+          );
+        }
+        nodes = parseCompanionSemanticsNodes(
+          response['nodes'] as List<dynamic>? ?? [],
+        );
+      } else {
+        // Fallback: evaluate-based path; coordinates are in local space.
+        nodes = await session.serviceExtensions!.getSemanticsTree();
+      }
+
       return CallToolResult(
         content: [TextContent(text: formatSemanticsTree(nodes))],
       );

--- a/lib/src/inspector/tools/get_semantics_tool.dart
+++ b/lib/src/inspector/tools/get_semantics_tool.dart
@@ -24,9 +24,6 @@ class GetSemanticsTool extends InspectorTool {
     inputSchema: Schema.object(properties: {}, required: []),
   );
 
-  // TODO: Implement typed wrappers for the slipstream agent ext. methods in
-  // FlutterServiceExtensions.
-
   @override
   Future<CallToolResult> handle(
     CallToolRequest request,
@@ -40,22 +37,17 @@ class GetSemanticsTool extends InspectorTool {
 
       if (session.hasCompanion) {
         // Use the companion extension — returns screen-space coordinates.
-        final extensions = session.serviceExtensions!;
-
-        var response = await extensions.callSlipstreamExtension(
-          'ext.slipstream.get_semantics',
-        );
-
-        if (response['ok'] != true) {
-          final error = response['error'] as String? ?? 'get_semantics failed';
+        final result =
+            await session.serviceExtensions!.slipstreamGetSemantics();
+        if (!result.ok) {
           return CallToolResult(
-            content: [TextContent(text: error)],
+            content: [
+              TextContent(text: result.error ?? 'get_semantics failed'),
+            ],
             isError: true,
           );
         }
-        nodes = parseCompanionSemanticsNodes(
-          response['nodes'] as List<dynamic>? ?? [],
-        );
+        nodes = result.nodes;
       } else {
         // Fallback: evaluate-based path; coordinates are in local space.
         nodes = await session.serviceExtensions!.getSemanticsTree();

--- a/lib/src/inspector/tools/navigate_tool.dart
+++ b/lib/src/inspector/tools/navigate_tool.dart
@@ -76,16 +76,11 @@ class NavigateTool extends InspectorTool {
     }
 
     try {
-      final response = await session.serviceExtensions!.callSlipstreamExtension(
-        'ext.slipstream.navigate',
-        args: {'path': path},
-      );
-      final bool ok = response['ok'] as bool? ?? false;
-      if (!ok) {
-        final String error = response['error'] as String? ?? 'navigate failed';
+      final result = await session.serviceExtensions!.slipstreamNavigate(path);
+      if (!result.ok) {
         return CallToolResult(
           isError: true,
-          content: [TextContent(text: error)],
+          content: [TextContent(text: result.error ?? 'navigate failed')],
         );
       }
       return CallToolResult(content: [TextContent(text: 'Navigated to $path')]);

--- a/lib/src/inspector/tools/perform_scroll_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_tool.dart
@@ -60,23 +60,16 @@ class PerformScrollTool extends InspectorTool {
     final String pixels = request.arguments!['pixels'] as String;
 
     try {
-      final response = await session.serviceExtensions!.callSlipstreamExtension(
-        'ext.slipstream.perform_action',
-        args: {
-          'action': 'scroll',
-          'finder': finder,
-          'finderValue': finderValue,
-          'direction': direction,
-          'pixels': pixels,
-        },
+      final result = await session.serviceExtensions!.slipstreamScroll(
+        finder: finder,
+        finderValue: finderValue,
+        direction: direction,
+        pixels: pixels,
       );
-      final bool ok = response['ok'] as bool? ?? false;
-      if (!ok) {
+      if (!result.ok) {
         return CallToolResult(
           isError: true,
-          content: [
-            TextContent(text: response['error'] as String? ?? 'scroll failed'),
-          ],
+          content: [TextContent(text: result.error ?? 'scroll failed')],
         );
       }
       return CallToolResult(

--- a/lib/src/inspector/tools/perform_scroll_until_visible_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_until_visible_tool.dart
@@ -69,25 +69,18 @@ class PerformScrollUntilVisibleTool extends InspectorTool {
         request.arguments!['scroll_finder_value'] as String;
 
     try {
-      final response = await session.serviceExtensions!.callSlipstreamExtension(
-        'ext.slipstream.perform_action',
-        args: {
-          'action': 'scroll_until_visible',
-          'finder': finder,
-          'finderValue': finderValue,
-          'scrollFinder': scrollFinder,
-          'scrollFinderValue': scrollFinderValue,
-        },
-      );
-      final bool ok = response['ok'] as bool? ?? false;
-      if (!ok) {
+      final result = await session.serviceExtensions!
+          .slipstreamScrollUntilVisible(
+            finder: finder,
+            finderValue: finderValue,
+            scrollFinder: scrollFinder,
+            scrollFinderValue: scrollFinderValue,
+          );
+      if (!result.ok) {
         return CallToolResult(
           isError: true,
           content: [
-            TextContent(
-              text:
-                  response['error'] as String? ?? 'scroll_until_visible failed',
-            ),
+            TextContent(text: result.error ?? 'scroll_until_visible failed'),
           ],
         );
       }

--- a/lib/src/inspector/tools/perform_set_text_tool.dart
+++ b/lib/src/inspector/tools/perform_set_text_tool.dart
@@ -60,24 +60,15 @@ class PerformSetTextTool extends InspectorTool {
     final String text = request.arguments!['text'] as String;
 
     try {
-      final response = await session.serviceExtensions!.callSlipstreamExtension(
-        'ext.slipstream.perform_action',
-        args: {
-          'action': 'set_text',
-          'finder': finder,
-          'finderValue': finderValue,
-          'text': text,
-        },
+      final result = await session.serviceExtensions!.slipstreamSetText(
+        finder: finder,
+        finderValue: finderValue,
+        text: text,
       );
-      final bool ok = response['ok'] as bool? ?? false;
-      if (!ok) {
+      if (!result.ok) {
         return CallToolResult(
           isError: true,
-          content: [
-            TextContent(
-              text: response['error'] as String? ?? 'set_text failed',
-            ),
-          ],
+          content: [TextContent(text: result.error ?? 'set_text failed')],
         );
       }
       return CallToolResult(

--- a/lib/src/inspector/tools/perform_tap_tool.dart
+++ b/lib/src/inspector/tools/perform_tap_tool.dart
@@ -52,17 +52,14 @@ class PerformTapTool extends InspectorTool {
     final String finderValue = request.arguments!['finder_value'] as String;
 
     try {
-      final response = await session.serviceExtensions!.callSlipstreamExtension(
-        'ext.slipstream.perform_action',
-        args: {'action': 'tap', 'finder': finder, 'finderValue': finderValue},
+      final result = await session.serviceExtensions!.slipstreamTap(
+        finder: finder,
+        finderValue: finderValue,
       );
-      final bool ok = response['ok'] as bool? ?? false;
-      if (!ok) {
+      if (!result.ok) {
         return CallToolResult(
           isError: true,
-          content: [
-            TextContent(text: response['error'] as String? ?? 'tap failed'),
-          ],
+          content: [TextContent(text: result.error ?? 'tap failed')],
         );
       }
       return CallToolResult(

--- a/lib/src/inspector/tools/run_app_tool.dart
+++ b/lib/src/inspector/tools/run_app_tool.dart
@@ -15,7 +15,7 @@ class RunAppTool extends InspectorTool {
   final Future<void> Function(AppSession session) registerSession;
 
   /// Called to forward daemon events from the session to the server.
-  final void Function(DaemonEvent event) eventListener;
+  final void Function(AppEvent event) eventListener;
 
   @override
   final Tool definition = Tool(
@@ -80,10 +80,10 @@ class RunAppTool extends InspectorTool {
     await registerSession(session);
 
     final String deviceInfo =
-        session.deviceId != null ? ' Device: ${session.deviceId}.' : '';
+        session.deviceId != null ? " (device ID: '${session.deviceId}')" : '';
     final String replaced = hadExisting ? ' Previous app was stopped.' : '';
     return CallToolResult(
-      content: [TextContent(text: 'Launched.$deviceInfo$replaced')],
+      content: [TextContent(text: 'Launched!$deviceInfo$replaced')],
     );
   }
 }


### PR DESCRIPTION
Integrates slipstream_agent companion events and the `ext.slipstream.get_semantics` extension into the MCP server.

- Forward `ext.slipstream.windowResized` events to MCP clients as `[window] WxH logical px (dpr=N)` log messages
- Forward `ext.slipstream.routeChanged` events as `[route] /path` log messages; drop the less reliable `Flutter.Navigation` forwarding
- Use `ext.slipstream.get_semantics` when the companion is present — returns screen-space coordinates (accumulated transforms), so the output now shows `position: X,Y WxH` instead of `size: WxH`
- Add typed wrappers in `FlutterServiceExtensions` for all `ext.slipstream.*` calls (`slipstreamTap`, `slipstreamSetText`, `slipstreamScroll`, `slipstreamScrollUntilVisible`, `slipstreamNavigate`, `slipstreamGetRoute`, `slipstreamEnableSemantics`, `slipstreamGetSemantics`); tools no longer call `callSlipstreamExtension` directly