### PR TITLE
Misc improvements: terse reload message, run_app path validation, study docs

### DIFF
--- a/docs/feedback-04.md
+++ b/docs/feedback-04.md
@@ -1,0 +1,29 @@
+# Flutter Slipstream Feedback
+
+## Work Log
+1.  **Project Setup**: Initialized dependencies (`provider`, `go_router`, `google_fonts`, `flutter_staggered_grid_view`, `slipstream_agent`).
+2.  **App Structure**: Created `lib/theme_provider.dart`, `lib/router.dart`, and `lib/pages/home_shell.dart`.
+3.  **App Launch**: Started the app on the macOS device using `mcp_slipstream-inspector_run_app`.
+4.  **Initial UI Check**: Verified basic structure with `take_screenshot` and `get_semantics`.
+5.  **Theme Implementation**: Added theme toggle to `HomeShell` and verified with `take_screenshot` in dark mode.
+6.  **Widget Showcase**: Built a page with Material 3 widgets and `google_fonts`. Verified font usage with `mcp_slipstream-packages_package_summary`.
+7.  **Mondrian Art**: Implemented a grid layout using `flutter_staggered_grid_view`. Used `mcp_slipstream-packages_class_stub` to understand API.
+8.  **Tic Tac Toe**: Created a game page. Fixed an overflow issue discovered by `take_screenshot` using `inspect_layout`.
+9.  **Interaction Testing**: Used `perform_tap` with a `byKey` finder to verify game interaction.
+
+## Pros
+-   **Visual Verification**: `take_screenshot` is incredibly helpful for immediate visual feedback without needing to manually look at a device. It helped catch the overflow issue early.
+-   **Package Documentation**: `slipstream-packages` tools (especially `package_summary` and `class_stub`) are much more reliable than relying on training data for API signatures. They provided exact parameters for `StaggeredGrid` and `GoogleFonts`.
+-   **Direct Interaction**: `perform_tap` and `navigate` make it easy to test deep navigation paths and interactions without writing full integration tests.
+-   **Semantic Inspection**: `get_semantics` provides a clear view of how the app is structured for accessibility and automation.
+-   **Hot Reload Integration**: The `reload` tool works seamlessly and is essential for iterative development.
+
+## Cons / Bugs / Potential Improvements
+-   **Screenshot Transparency**: The screenshots sometimes show "DEBUG" banner or system overlays which can be distracting, though this is standard Flutter behavior.
+-   **Semantic Labels**: The theme toggle button (IconButton) didn't show the `tooltip` as a label in `get_semantics`. I had to add a `semanticsLabel` or similar for it to be more discoverable via semantics (though `byKey` worked great).
+-   **Layout Inspection Depth**: `inspect_layout` output can be very large and verbose. A way to filter by widget type or search for a specific widget ID would be useful.
+-   **App Launch Speed**: The first build takes some time, but subsequent reloads are fast.
+-   **Device selection**: Auto-selecting the best device is great, but maybe a way to list available devices first would be nice for specific target testing.
+
+## Summary
+Flutter Slipstream significantly speeds up the development and debugging cycle for AI agents. The combination of visual feedback (`take_screenshot`) and accurate API data (`slipstream-packages`) reduces the "hallucination" risk when using third-party packages.

--- a/docs/study-setup.md
+++ b/docs/study-setup.md
@@ -50,3 +50,37 @@ bugs, and things which could improve the tool - as well as a work log - to
 /Users/.../flutter-agent-tools/docs/feedback-xx.md.
 
 Do you have any questions before you begin?
+
+## Gemini
+
+Hi! We're testing out new coding agent tooling in the form of two MCP servers,
+'slipstream-inspector' and 'slipstream-packages'. The general tool is Flutter
+Slipstream: "A tool that makes AI coding agents more effective for Dart and
+Flutter projects.".
+
+Your job is to test the tool - learn what it does well and where it could
+improve - and provide feedback about it. Please familiarize yourself with its
+MCP tools. In order to test it you'll be building an app. This directory is
+populated with a standard hello-world Flutter app. Please - working
+iteratively - turn it into a working Flutter app.
+
+- Try and use popular and common packages, like provider and go_router.
+- Feel free to use packages you're less familiar with, in order to test out the
+  tool's features.
+- Have a theme toggle.
+- Use a Scaffold and a drawer.
+- Use a bottom navigation bar.
+- In one page of the navigation bar include a very small widget showcase.
+- In another, include a Mondrian art page.
+- In another, include a small game (tic tac toe? something else?).
+
+Building the app is a mechanism for testing this tool. You can assume a mobile
+phone target / mobile phone screen dimensions.
+
+Relatively early in your work, please start the app. Then - work iteratively -
+hot reload at regular intervals. You should work independently; if you get stuck
+skip the section you're working on. Once you're done, please write your
+feedback - pros, cons, bugs, and things which could improve the tool - as well
+as a work log - to 'feedback.md' in the current directory.
+
+Do you have any questions before you begin?

--- a/lib/src/inspector/tools/reload_tool.dart
+++ b/lib/src/inspector/tools/reload_tool.dart
@@ -53,9 +53,7 @@ class ReloadTool extends InspectorTool {
         TextContent(
           text:
               '$action complete. '
-              'Note: semantics node IDs are reassigned after each reload — '
-              're-fetch with get_semantics before using any '
-              'previously observed node IDs.',
+              'Semantics node IDs reset — call get_semantics before reusing any.',
         ),
       ],
     );

--- a/lib/src/inspector/tools/run_app_tool.dart
+++ b/lib/src/inspector/tools/run_app_tool.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:dart_mcp/server.dart';
 
+import '../../common.dart';
 import '../app_session.dart';
 import '../tool_context.dart';
 
@@ -29,7 +32,9 @@ class RunAppTool extends InspectorTool {
     inputSchema: Schema.object(
       properties: {
         'working_directory': Schema.string(
-          description: 'The Flutter project directory to launch.',
+          description:
+              'The Flutter project directory to launch.\n\n'
+              'Note that this should be an absolute path.',
         ),
         'target': Schema.string(
           description:
@@ -59,7 +64,18 @@ class RunAppTool extends InspectorTool {
     final String? device = args['device'] as String?;
     final String? target = args['target'] as String?;
 
-    final bool hadExisting = context.activeSession != null;
+    final dir = Directory(workingDirectory);
+    if (!dir.isAbsolute) {
+      throw ToolException("working_directory should be an absolute path.");
+    }
+
+    final previousSession = context.removeSession();
+    if (previousSession != null) {
+      await previousSession.stop().timeout(
+        Duration(milliseconds: 250),
+        onTimeout: () => null,
+      );
+    }
 
     final AppSession session;
     try {
@@ -70,6 +86,7 @@ class RunAppTool extends InspectorTool {
         target: target,
         debugLog: (message) => context.log(LoggingLevel.info, message),
       );
+      await registerSession(session);
     } on DaemonException catch (e) {
       return CallToolResult(
         isError: true,
@@ -77,11 +94,10 @@ class RunAppTool extends InspectorTool {
       );
     }
 
-    await registerSession(session);
-
     final String deviceInfo =
         session.deviceId != null ? " (device ID: '${session.deviceId}')" : '';
-    final String replaced = hadExisting ? ' Previous app was stopped.' : '';
+    final String replaced =
+        previousSession != null ? '\n\nPrevious app was stopped.' : '';
     return CallToolResult(
       content: [TextContent(text: 'Launched!$deviceInfo$replaced')],
     );


### PR DESCRIPTION
Small assortment of fixes and improvements.

- Shorten the hot reload/restart semantics ID note to: `"Semantics node IDs reset — call get_semantics before reusing any."`
- `run_app`: validate that `working_directory` is an absolute path; stop any previous session before launching (not after) so an error during launch doesn't orphan the old session
- Add Gemini study setup variant to `docs/study-setup.md`; add `docs/feedback-04.md`