### PR TITLE
Prep for 1.0.0 marketplace release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Flutter/Dart agent tooling: dependency health, package API summarization, and UI runtime introspection.",
   "author": {
     "name": "Devon Carew",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+## 1.0.0
+
+Initial public release.
+
+### Package currency hook
+
+- Warns when an agent adds a discontinued package (with official replacement if
+  one is listed)
+- Warns when a constraint targets an older major version than the current pub.dev
+  release
+- Warns when a package name is not found on pub.dev
+- Fires on `flutter pub add` / `dart pub add` and on direct `pubspec.yaml` edits
+- Always exits 0 — advisory only, never hard-blocks
+
+### `packages` MCP server
+
+- `package_summary` — version, entry-point import, README excerpt, public
+  library list, and exported name groups
+- `library_stub` — full public API for one library as a Dart stub file
+  (signatures only, no bodies)
+- `class_stub` — stub for a single named class, mixin, or extension
+
+### `inspector` MCP server
+
+- `run_app` — builds and launches a Flutter app; auto-selects the best
+  available device (desktop > simulator > emulator > physical > web)
+- `reload` — hot reload or hot restart
+- `take_screenshot` — PNG screenshot via the inspector protocol
+- `inspect_layout` — widget layout tree (subtree depth configurable)
+- `evaluate` — arbitrary Dart expression on the main isolate
+- `get_route` — navigator stack with screen widget names and source locations
+- `navigate` — route navigation via registered router adapter (requires
+  `slipstream_agent` companion)
+- `get_semantics` — flat list of visible semantics nodes with role, ID, state,
+  actions, label, and position
+- `perform_semantic_action` — semantics action (tap, longPress, setText, …) by
+  node ID or label
+- `perform_tap` — finder-based tap (byKey/byType/byText/bySemanticsLabel);
+  requires `slipstream_agent` companion
+- `perform_set_text` — finder-based text field input; requires companion
+- `perform_scroll` — scroll a Scrollable by fixed logical pixels; requires
+  companion
+- `perform_scroll_until_visible` — scroll until a target widget is in the
+  viewport; requires companion
+- `close_app` — stops the running app
+
+### `slipstream_agent` companion integration
+
+When `package:slipstream_agent` is installed in the target app, the inspector
+server detects it via `ext.slipstream.ping` and activates enhanced mode:
+
+- Finder-based widget interaction (byKey, byType, byText, bySemanticsLabel)
+- Router-adapter navigation (GoRouter and others)
+- Semantics nodes with accurate screen-space coordinates
+- `[window]` log messages on resize
+- `[route]` log messages on navigation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,8 @@ Session lifecycle: `run_app` starts a session; `close_app` ends it. Only one
 session is active at a time — `run_app` silently stops any existing session
 before launching.
 
-- `run_app` — builds and launches a Flutter app; `working_directory` must be
-  an absolute path
+- `run_app` — builds and launches a Flutter app; `working_directory` must be an
+  absolute path
 - `reload` — hot reload (`full_restart: false`, default) or hot restart
   (`full_restart: true`)
 - `take_screenshot` — captures a PNG screenshot via the inspector protocol
@@ -58,8 +58,8 @@ before launching.
   screen-space coordinates when companion is present
 - `perform_semantic_action` — dispatches a semantics action (tap, longPress,
   setText, …) by semantics node ID or label; no companion required
-- `perform_tap` — taps a widget by finder (byKey/byType/byText/bySemanticsLabel);
-  requires `slipstream_agent` companion
+- `perform_tap` — taps a widget by finder
+  (byKey/byType/byText/bySemanticsLabel); requires `slipstream_agent` companion
 - `perform_set_text` — sets text field content by finder; requires companion
 - `perform_scroll` — scrolls a Scrollable by fixed pixels; requires companion
 - `perform_scroll_until_visible` — scrolls until a target widget is visible;
@@ -68,11 +68,12 @@ before launching.
 
 ### slipstream_agent companion (`package:slipstream_agent`)
 
-An optional dev dependency apps can install for richer instrumentation. When
-present (detected via `ext.slipstream.ping`), the inspector server uses
-in-process service extensions instead of evaluate-based fallbacks:
+An optional dependency apps can install for richer instrumentation. When present
+(detected via `ext.slipstream.ping`), the inspector server uses in-process
+service extensions instead of evaluate-based fallbacks:
 
-- `ext.slipstream.perform_action` — finder-based tap/set_text/scroll/scroll_until_visible
+- `ext.slipstream.perform_action` — finder-based
+  tap/set_text/scroll/scroll_until_visible
 - `ext.slipstream.navigate` — router-adapter navigation
 - `ext.slipstream.get_route` — current route path from the router adapter
 - `ext.slipstream.get_semantics` — semantics nodes with screen-space coordinates
@@ -80,9 +81,9 @@ in-process service extensions instead of evaluate-based fallbacks:
 - `ext.slipstream.routeChanged` event — forwarded as `[route] /path` log
 
 Typed wrappers for all companion calls live in
-`lib/src/inspector/flutter_service_extensions.dart`
-(`slipstreamTap`, `slipstreamSetText`, etc.). Never call
-`callSlipstreamExtension` directly from tool code.
+`lib/src/inspector/flutter_service_extensions.dart` (`slipstreamTap`,
+`slipstreamSetText`, etc.). Never call `callSlipstreamExtension` directly from
+tool code.
 
 ## Current Status
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,14 @@ observe a running Flutter app.
   `.claude-plugin/plugin.json`.
 - Package currency hook: `bin/deps_check.dart`, invoked via
   `scripts/deps_check.sh --mode=pub-add|pubspec-guard`. Configured in
-  `hooks/hooks.json`.
+  `.claude-plugin/plugin.json`.
 - Hooks receive tool input as JSON on stdin; exit 0 always (warnings only —
   hard-blocking is reserved for cases where proceeding would be clearly wrong).
 - Use `${CLAUDE_PLUGIN_ROOT}` for all paths in hook commands — never hardcode.
 - Fail open on infrastructure errors (network timeout, etc.): don't block the
   agent over tooling failures.
+- Plugin version is tracked in `.claude-plugin/plugin.json` (not `pubspec.yaml`,
+  which has `publish_to: none`).
 
 ## Registered MCP Tools
 
@@ -36,19 +38,51 @@ observe a running Flutter app.
 
 ### inspector server (`bin/inspector_mcp.dart`)
 
-- `run_app` — builds and launches a Flutter app, returns a session ID
-- `reload` — hot reload or hot restart a running app
+Session lifecycle: `run_app` starts a session; `close_app` ends it. Only one
+session is active at a time — `run_app` silently stops any existing session
+before launching.
+
+- `run_app` — builds and launches a Flutter app; `working_directory` must be
+  an absolute path
+- `reload` — hot reload (`full_restart: false`, default) or hot restart
+  (`full_restart: true`)
 - `take_screenshot` — captures a PNG screenshot via the inspector protocol
-- `inspect_layout` — returns the layout tree for a widget (or root)
+- `inspect_layout` — returns the widget layout tree; `widget_id` omitted → root
 - `evaluate` — evaluates an arbitrary Dart expression on the main isolate
-- `get_route` — returns the navigator stack with screen names and source
-  locations; enriches with go_router path when available
-- `navigate` — navigates to a go_router path via `GoRouter.go()`
-- `get_semantics` — returns a flat list of visible semantics nodes (role, ID,
-  state, actions, label, size); node IDs usable with 'tap'
-- `tap` — tap an element by semantics node ID or label
-- `set_text` — set text field content by semantics node ID or label
-- `close_app` — stops a running app and releases its session
+- `get_route` — navigator stack with screen widget names and source locations;
+  enriched with the current router path when `slipstream_agent` is installed
+- `navigate` — navigates to a route path via the registered router adapter;
+  requires `slipstream_agent` companion
+- `get_semantics` — flat list of visible semantics nodes (role, ID, state,
+  actions, label, position/size); uses `ext.slipstream.get_semantics` with
+  screen-space coordinates when companion is present
+- `perform_semantic_action` — dispatches a semantics action (tap, longPress,
+  setText, …) by semantics node ID or label; no companion required
+- `perform_tap` — taps a widget by finder (byKey/byType/byText/bySemanticsLabel);
+  requires `slipstream_agent` companion
+- `perform_set_text` — sets text field content by finder; requires companion
+- `perform_scroll` — scrolls a Scrollable by fixed pixels; requires companion
+- `perform_scroll_until_visible` — scrolls until a target widget is visible;
+  requires companion
+- `close_app` — stops the running app and releases its session
+
+### slipstream_agent companion (`package:slipstream_agent`)
+
+An optional dev dependency apps can install for richer instrumentation. When
+present (detected via `ext.slipstream.ping`), the inspector server uses
+in-process service extensions instead of evaluate-based fallbacks:
+
+- `ext.slipstream.perform_action` — finder-based tap/set_text/scroll/scroll_until_visible
+- `ext.slipstream.navigate` — router-adapter navigation
+- `ext.slipstream.get_route` — current route path from the router adapter
+- `ext.slipstream.get_semantics` — semantics nodes with screen-space coordinates
+- `ext.slipstream.windowResized` event — forwarded as `[window] WxH` log
+- `ext.slipstream.routeChanged` event — forwarded as `[route] /path` log
+
+Typed wrappers for all companion calls live in
+`lib/src/inspector/flutter_service_extensions.dart`
+(`slipstreamTap`, `slipstreamSetText`, etc.). Never call
+`callSlipstreamExtension` directly from tool code.
 
 ## Current Status
 
@@ -57,25 +91,29 @@ observe a running Flutter app.
   check, old major version check, pubspec-guard mode all implemented
 - packages MCP server: functional — `package_summary`, `library_stub`, and
   `class_stub` all implemented
-- inspector MCP server: functional — launch, reload, close, take_screenshot,
-  inspect layout, evaluate, get_route (with go_router path enrichment),
-  navigate, get_semantics, and tap all working
-- Flutter.Error events are pushed to agents with widget IDs for use with
-  `inspect_layout`
+- inspector MCP server: functional — all tools above implemented and working
+- `slipstream_agent` companion detection and event forwarding: implemented
+- Flutter.Error events are pushed to agents as MCP log warnings with widget IDs
 
 ## Development
 
 ```sh
-# Test the deps-check hook directly:
+# Run all tests:
+dart test
+
+# Test the deps-check hook manually:
 echo '{"tool_name":"Bash","tool_input":{"command":"flutter pub add http"}}' \
   | dart run bin/deps_check.dart --mode=pub-add
 
 # Load the plugin locally:
 claude --plugin-dir /path/to/flutter-slipstream
+
+# Regenerate the README command tables:
+dart run tool/generate_readme.dart
 ```
 
 ## Design Reference
 
-See `DESIGN.md` for the full architecture and planned tool designs.
+See `docs/DESIGN.md` for the full architecture and planned tool designs.
 
 See `docs/inspector.md` for a Flutter runtime inspection guide for AI agents.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ for launching, inspecting, and interacting with a running Flutter app.
 ## Installation
 
 ```sh
-# Test locally:
-claude --plugin-dir </path/to>/flutter-slipstream
+claude plugin add flutter-slipstream
+```
+
+Or to test from a local checkout:
+
+```sh
+claude --plugin-dir /path/to/flutter-slipstream
 ```
 
 ## Tools

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,4 +1,4 @@
-# Design: Flutter Agent Tools
+# Design: Flutter Slipstream
 
 ## Problem Statement
 

--- a/docs/inspector.md
+++ b/docs/inspector.md
@@ -304,5 +304,6 @@ rendered frame).
 
 ## 8. Further Reading
 
-See `DESIGN.md` for the full tool surface, implementation status, and design
-rationale. This document focuses on the underlying protocol and data structures.
+See `docs/DESIGN.md` for the full tool surface, implementation status, and
+design rationale. This document focuses on the underlying protocol and data
+structures.

--- a/docs/slipstream_doc.md
+++ b/docs/slipstream_doc.md
@@ -127,6 +127,9 @@ replaced. Flutter.Error events from the running app are automatically forwarded
 as MCP log warnings — no polling needed.
 
 - `working_directory`: (required) The Flutter project directory to launch.
+
+Note that this should be an absolute path.
+
 - `target`: The main entry point to launch (e.g. lib/main.dart). Defaults to the
   project default.
 - `device`: Optional device ID override. When omitted, auto-selects the best

--- a/lib/src/inspector/flutter_service_extensions.dart
+++ b/lib/src/inspector/flutter_service_extensions.dart
@@ -93,7 +93,7 @@ class FlutterServiceExtensions {
     required String finder,
     required String finderValue,
     required String direction,
-    required String pixels,
+    required double pixels,
   }) => _slipstreamAction({
     'action': 'scroll',
     'finder': finder,

--- a/lib/src/inspector/tool_context.dart
+++ b/lib/src/inspector/tool_context.dart
@@ -76,8 +76,8 @@ class ToolContext {
           text:
               '$toolName: the slipstream_agent companion package is not '
               'installed in this app.\n\n'
-              'Add it as a dev dependency:\n\n'
-              '  dev_dependencies:\n'
+              'Add it as a dependency:\n\n'
+              '  dependencies:\n'
               '    slipstream_agent: ^0.1.0\n\n'
               'Then call SlipstreamAgent.init() in your main() inside '
               'kDebugMode.\n\n'

--- a/lib/src/inspector/tools/navigate_tool.dart
+++ b/lib/src/inspector/tools/navigate_tool.dart
@@ -55,8 +55,8 @@ class NavigateTool extends InspectorTool {
             text:
                 'navigate: the slipstream_agent companion package is not '
                 'installed in this app.\n\n'
-                'Add it as a dev dependency and register a router adapter:\n\n'
-                '  dev_dependencies:\n'
+                'Add it as a dependency and register a router adapter:\n\n'
+                '  dependencies:\n'
                 '    slipstream_agent: ^0.1.0\n\n'
                 'Then in main():\n\n'
                 '  if (kDebugMode) {\n'

--- a/lib/src/inspector/tools/perform_scroll_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_tool.dart
@@ -1,6 +1,7 @@
 import 'package:dart_mcp/server.dart';
 import 'package:vm_service/vm_service.dart' show RPCError;
 
+import '../../utils.dart';
 import '../tool_context.dart';
 
 const _finderDescription =
@@ -33,7 +34,7 @@ class PerformScrollTool extends InspectorTool {
         'direction': Schema.string(
           description: 'Scroll direction: "up", "down", "left", or "right".',
         ),
-        'pixels': Schema.string(
+        'pixels': Schema.num(
           description: 'Number of logical pixels to scroll.',
         ),
       },
@@ -57,7 +58,7 @@ class PerformScrollTool extends InspectorTool {
     final String finder = request.arguments!['finder'] as String;
     final String finderValue = request.arguments!['finder_value'] as String;
     final String direction = request.arguments!['direction'] as String;
-    final String pixels = request.arguments!['pixels'] as String;
+    final double pixels = coerceDouble(request.arguments!['pixels'])!;
 
     try {
       final result = await session.serviceExtensions!.slipstreamScroll(

--- a/lib/src/inspector/tools/take_screenshot_tool.dart
+++ b/lib/src/inspector/tools/take_screenshot_tool.dart
@@ -1,6 +1,7 @@
 import 'package:dart_mcp/server.dart';
 import 'package:vm_service/vm_service.dart' show RPCError;
 
+import '../../utils.dart';
 import '../tool_context.dart';
 
 /// Implements the `take_screenshot` MCP tool.
@@ -38,8 +39,7 @@ class TakeScreenshotTool extends InspectorTool {
     final session = context.activeSession;
     if (session == null) return context.noActiveSession();
 
-    final num? pixelRatioArg = request.arguments!['pixel_ratio'] as num?;
-    final double? pixelRatio = pixelRatioArg?.toDouble();
+    final pixelRatio = coerceDouble(request.arguments!['pixel_ratio']);
 
     try {
       final String base64Data = await session.takeScreenshot(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,6 +26,15 @@ bool? coerceBool(Object? value) => switch (value) {
   _ => null,
 };
 
+double? coerceDouble(Object? value) {
+  if (value == null) return null;
+  return switch (value) {
+    num n => n.toDouble(),
+    String s => double.tryParse(s),
+    _ => null,
+  };
+}
+
 Object? jsonTryParse(String source) {
   try {
     return jsonDecode(source);


### PR DESCRIPTION
Gets the repo ready for the first public marketplace release.

- Bump plugin version to `1.0.0` in `.claude-plugin/plugin.json`
- Add `CHANGELOG.md` documenting all 1.0.0 features (hook, packages server, inspector server, companion integration)
- Move `DESIGN.md` → `docs/DESIGN.md`; update all references
- Update `README.md` installation section with `claude plugin add flutter-slipstream`
- Rewrite `CLAUDE.md` to reflect the current codebase: accurate tool list, single-session model, companion extension surface, typed wrapper convention