### PR TITLE
Add slipstreamLog and slipstreamOverlays companion wrappers

### DIFF
--- a/lib/src/inspector/app_session.dart
+++ b/lib/src/inspector/app_session.dart
@@ -43,6 +43,9 @@ class AppSession {
 
   final DebugLogger debugLog;
 
+  // Used to time reload / restart operations.
+  Stopwatch? reloadTimer;
+
   final Completer<void> _startedCompleter = Completer<void>();
   int _nextId = 0;
   final Map<int, Completer<Map<String, dynamic>>> _pending = {};
@@ -52,7 +55,11 @@ class AppSession {
 
   String? _vmServiceUri;
   FlutterServiceExtensions? _serviceExtensions;
-  StreamSubscription<Event>? _vmServiceSubscription;
+  StreamSubscription<Event>? _vmIsolateEventSubscription;
+  StreamSubscription<Event>? _vmExtensionEventSubscription;
+
+  // TODO: We need to null this out when the associated isolate stops (as part
+  // of a hot restart).
   String? _companionVersion;
 
   // Capped at [_maxErrors] most-recent errors; cleared on hot restart.
@@ -409,12 +416,49 @@ class AppSession {
         _devToolsUri = params['uri'] as String?;
       } else if (event == 'app.dtd') {
         _dtdToolsUri = params['uri'] as String?;
+      } else if (event == 'app.progress') {
+        // {id: '2', progressId: 'hot.reload', finished: true}
+        final progressId = params['progressId'] as String? ?? '';
+        final finished = params['finished'] == true;
+
+        if (finished && progressId == 'hot.reload') {
+          final duration = reloadTimer?.elapsed;
+          reloadTimer = null;
+
+          if (hasCompanion) {
+            serviceExtensions?.slipstreamLog(
+              'reload',
+              kind: 'reload',
+              details: describeShortDuration(duration),
+            );
+          }
+        } else if (finished && progressId == 'hot.restart') {
+          // Stop the timer now. The companion agent hasn't had a chance to boot
+          // up and register its 'ping' or 'log' extensions. Wait until we see
+          // an extension registragion go by for them, then send a
+          // slipstreamLog('restart') message.
+          reloadTimer?.stop();
+        }
       }
 
       if (!_sessionEnded) {
         _eventListener(AppEvent(event, params));
       }
     }
+  }
+
+  // Perform the second half of a hot restart notification. We've already
+  // stopped the timer, and we're only called here after the companion agent
+  // has become available.
+  void _checkHotRestartTimer() {
+    final duration = reloadTimer?.elapsed;
+    reloadTimer = null;
+
+    serviceExtensions?.slipstreamLog(
+      'restart',
+      kind: 'reload',
+      details: describeShortDuration(duration),
+    );
   }
 
   Future<void> _connectVmService(String wsUri) async {
@@ -431,9 +475,27 @@ class AppSession {
     // Detect companion package. Best-effort — fails open if not installed.
     _pingCompanion();
 
-    await vmService.streamListen(EventStreams.kExtension);
+    // Isolate events
+    vmService.streamListen(EventStreams.kIsolate).ignore();
+    _vmIsolateEventSubscription = vmService.onIsolateEvent.listen((
+      Event event,
+    ) {
+      // Also available:
+      //   kIsolateStart, kIsolateRunnable, kIsolateExit, kIsolateReload
 
-    _vmServiceSubscription = vmService.onExtensionEvent.listen((Event event) {
+      if (event.kind == EventKind.kServiceExtensionAdded) {
+        final rpcName = event.extensionRPC;
+        if (rpcName == 'ext.slipstream.ping') {
+          _pingCompanion(ifAvailable: _checkHotRestartTimer);
+        }
+      }
+    });
+
+    // Extension events
+    vmService.streamListen(EventStreams.kExtension).ignore();
+    _vmExtensionEventSubscription = vmService.onExtensionEvent.listen((
+      Event event,
+    ) {
       if (event.extensionKind == 'Flutter.Error') {
         final data = event.extensionData?.data;
         if (data != null) {
@@ -473,9 +535,13 @@ class AppSession {
 
   /// Calls [FlutterServiceExtensions.pingCompanion] and stores the result.
   /// Best-effort — called on initial connect and after each hot restart.
-  void _pingCompanion() {
+  void _pingCompanion({Function? ifAvailable}) {
     _serviceExtensions?.pingCompanion().then((version) {
       _companionVersion = version;
+
+      if (ifAvailable != null) {
+        ifAvailable();
+      }
     });
   }
 
@@ -499,8 +565,10 @@ class AppSession {
 
     _sessionEnded = true;
 
-    _vmServiceSubscription?.cancel();
-    _vmServiceSubscription = null;
+    _vmIsolateEventSubscription?.cancel();
+    _vmIsolateEventSubscription = null;
+    _vmExtensionEventSubscription?.cancel();
+    _vmExtensionEventSubscription = null;
     _serviceExtensions?.dispose();
     _serviceExtensions = null;
   }

--- a/lib/src/inspector/flutter_service_extensions.dart
+++ b/lib/src/inspector/flutter_service_extensions.dart
@@ -196,12 +196,32 @@ class FlutterServiceExtensions {
   /// (`perform_action`, `navigate`, etc.) log themselves automatically — call
   /// this only for operations that go through the MCP server directly.
   ///
+  /// [kind] is the icon category shown in the overlay:
+  /// `"reload"`, `"screenshot"`, `"read"`, or `"interact"`.
+  ///
+  /// [finder] and [finderValue] identify the widget of interest (used with
+  /// `viz: "outline"` or `viz: "layout"`).
+  ///
+  /// [viz] requests an extra visualisation:
+  /// `"flash"`, `"outline"`, `"layout"`, or `"semantics"`.
+  ///
   /// Best-effort: failures are silently ignored so a logging hiccup never
   /// breaks the calling tool.
-  Future<void> slipstreamLog(String command, {String? details}) async {
+  Future<void> slipstreamLog(
+    String command, {
+    String? details,
+    String? kind,
+    String? finder,
+    String? finderValue,
+    String? viz,
+  }) async {
     try {
       final Map<String, dynamic> args = {'command': command};
       if (details != null) args['details'] = details;
+      if (kind != null) args['kind'] = kind;
+      if (finder != null) args['finder'] = finder;
+      if (finderValue != null) args['finderValue'] = finderValue;
+      if (viz != null) args['viz'] = viz;
       await _callExtension('ext.slipstream.log', args: args);
     } catch (_) {
       // Logging is best-effort — never let it break the calling tool.

--- a/lib/src/inspector/flutter_service_extensions.dart
+++ b/lib/src/inspector/flutter_service_extensions.dart
@@ -187,6 +187,44 @@ class FlutterServiceExtensions {
     );
   }
 
+  /// Calls `ext.slipstream.log` to record an agent command in the ghost
+  /// overlay command log.
+  ///
+  /// [command] is a short label such as `"reload"`, `"screenshot"`, or
+  /// `"evaluate"`. [details] is an optional string appended after a colon
+  /// (e.g. a path or expression snippet). In-process extensions
+  /// (`perform_action`, `navigate`, etc.) log themselves automatically — call
+  /// this only for operations that go through the MCP server directly.
+  ///
+  /// Best-effort: failures are silently ignored so a logging hiccup never
+  /// breaks the calling tool.
+  Future<void> slipstreamLog(String command, {String? details}) async {
+    try {
+      final Map<String, dynamic> args = {'command': command};
+      if (details != null) args['details'] = details;
+      await _callExtension('ext.slipstream.log', args: args);
+    } catch (_) {
+      // Logging is best-effort — never let it break the calling tool.
+    }
+  }
+
+  /// Calls `ext.slipstream.overlays` to show or hide Slipstream-managed
+  /// overlays (currently the Flutter debug banner).
+  ///
+  /// Pass `enabled: false` before taking a screenshot to hide overlays, then
+  /// `enabled: true` to restore them. Best-effort: failures are silently
+  /// ignored.
+  Future<void> slipstreamOverlays({required bool enabled}) async {
+    try {
+      await _callExtension(
+        'ext.slipstream.overlays',
+        args: {'enabled': enabled},
+      );
+    } catch (_) {
+      // Best-effort — don't let an overlay failure break the screenshot.
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Semantics
 

--- a/lib/src/inspector/semantic_node.dart
+++ b/lib/src/inspector/semantic_node.dart
@@ -31,9 +31,9 @@ class SemanticNode {
   final int id;
 
   /// Role derived from the node's flags: 'button', 'textfield', 'slider',
-  /// 'link', 'image', 'header', 'checkbox', 'toggle', 'radio', or '' for
+  /// 'link', 'image', 'header', 'checkbox', 'toggle', 'radio', or null for
   /// plain text/containers.
-  final String role;
+  final String? role;
 
   /// Primary accessibility label.
   final String label;
@@ -148,7 +148,7 @@ List<SemanticNode> parseCompanionSemanticsNodes(List<dynamic> nodes) {
 SemanticNode _nodeFromMap(Map<String, dynamic> m) {
   return SemanticNode(
     id: m['id'] as int,
-    role: m['role'] as String? ?? '',
+    role: m['role'] as String?,
     label: m['label'] as String? ?? '',
     value: m['value'] as String? ?? '',
     hint: m['hint'] as String? ?? '',

--- a/lib/src/inspector/semantics_formatter.dart
+++ b/lib/src/inspector/semantics_formatter.dart
@@ -41,7 +41,7 @@ String _formatNode(SemanticNode node) {
   // Supported actions on the header line.
   final actionsStr = node.describeActions.map((a) => ' action:$a').join('');
 
-  final role = node.role.isNotEmpty ? node.role : 'text';
+  final role = node.role ?? 'text';
   buf.writeln('[$role id=${node.id}$statesStr$actionsStr]');
 
   if (node.label.isNotEmpty) {
@@ -80,7 +80,7 @@ final RegExp _stripTrailingZeros = RegExp(r'\.?0+$');
 bool _hasContent(SemanticNode node) {
   if (node.describeState.isNotEmpty) return true;
   if (node.actions != 0) return true;
-  if (node.role.isNotEmpty) return true;
+  if (node.role != null) return true;
 
   return node.label.isNotEmpty || node.value.isNotEmpty || node.hint.isNotEmpty;
 }

--- a/lib/src/inspector/tool_context.dart
+++ b/lib/src/inspector/tool_context.dart
@@ -90,9 +90,7 @@ class ToolContext {
 
   /// Returns an error result for a VM service [RPCError].
   CallToolResult rpcError(RPCError e) {
-    // TODO: We need to double check what we're doing here. Sometimes e.details
-    // is populated with information we want to preserve. Should we just be
-    // doing
+    // TODO: We need to double check what we're doing here.
     final details = e.details;
     final error = ServiceError.tryParse(e);
     return CallToolResult(

--- a/lib/src/inspector/tools/evaluate_tool.dart
+++ b/lib/src/inspector/tools/evaluate_tool.dart
@@ -71,7 +71,7 @@ class EvaluateTool extends InspectorTool {
             expression.length > 60
                 ? '${expression.substring(0, 59)}…'
                 : expression;
-        extensions.slipstreamLog('evaluate', details: '"$msg"');
+        extensions.slipstreamLog('evaluate', details: '"$msg"', kind: 'read');
       }
       final String result = await extensions.evaluate(
         expression,

--- a/lib/src/inspector/tools/evaluate_tool.dart
+++ b/lib/src/inspector/tools/evaluate_tool.dart
@@ -65,7 +65,15 @@ class EvaluateTool extends InspectorTool {
         .replaceAll('&amp;', '&');
     final String? libraryUri = request.arguments!['library_uri'] as String?;
     try {
-      final String result = await session.serviceExtensions!.evaluate(
+      final extensions = session.serviceExtensions!;
+      if (session.hasCompanion) {
+        final msg =
+            expression.length > 60
+                ? '${expression.substring(0, 59)}…'
+                : expression;
+        extensions.slipstreamLog('evaluate', details: '"$msg"');
+      }
+      final String result = await extensions.evaluate(
         expression,
         libraryUri: libraryUri,
       );

--- a/lib/src/inspector/tools/inspect_layout_tool.dart
+++ b/lib/src/inspector/tools/inspect_layout_tool.dart
@@ -40,7 +40,9 @@ class InspectLayoutTool extends InspectorTool {
     ToolContext context,
   ) async {
     final session = context.activeSession;
-    if (session == null) return context.noActiveSession();
+    if (session == null) {
+      return context.noActiveSession();
+    }
 
     final String? widgetId = request.arguments!['widget_id'] as String?;
     final int subtreeDepth =
@@ -80,6 +82,18 @@ class InspectLayoutTool extends InspectorTool {
         subtreeDepth: subtreeDepth,
       );
       final layoutSummary = formatLayoutDetails(node, maxDepth: subtreeDepth);
+      if (session.hasCompanion) {
+        // We don't have a way to pass Flutter Inspector IDs as a widget finder.
+        // That's not really an issue; for the moment it means that the widget
+        // under inspection won't flash. In the future we may have an
+        // 'ext.slipstream.inspect_layout', which would be finder based.
+        extensions.slipstreamLog(
+          'inspect layout',
+          details: widgetId,
+          kind: 'read',
+          viz: 'layout',
+        );
+      }
       return CallToolResult(content: [TextContent(text: layoutSummary)]);
     } on RPCError catch (e) {
       return context.rpcError(e);

--- a/lib/src/inspector/tools/perform_semantic_action_tool.dart
+++ b/lib/src/inspector/tools/perform_semantic_action_tool.dart
@@ -91,12 +91,23 @@ class PerformSemanticActionTool extends InspectorTool {
     }
 
     try {
-      final result = await session.serviceExtensions!.performSemanticsAction(
+      final extensions = session.serviceExtensions!;
+      final result = await extensions.performSemanticsAction(
         actionType: action,
         nodeId: nodeId,
         label: label,
         arguments: value,
       );
+      if (session.hasCompanion) {
+        final String target = nodeId != null ? 'id=$nodeId' : '"$label"';
+        // We don't have a semantic ID finder type. We may consider adding one?
+        // It could also be used for 'perform_tap', ...
+        extensions.slipstreamLog(
+          'perform semantic',
+          details: '$action $target',
+          kind: 'interact',
+        );
+      }
       return CallToolResult(content: [TextContent(text: result)]);
     } on RPCError catch (e) {
       return context.rpcError(e);

--- a/lib/src/inspector/tools/reload_tool.dart
+++ b/lib/src/inspector/tools/reload_tool.dart
@@ -48,6 +48,15 @@ class ReloadTool extends InspectorTool {
     }
 
     final String action = fullRestart ? 'Hot restart' : 'Hot reload';
+
+    if (session.hasCompanion) {
+      // TODO: This may be too early to call 'log'. Consider delaying it until
+      // we know the companion package is available.
+      session.serviceExtensions?.slipstreamLog(
+        fullRestart ? 'restart' : 'reload',
+      );
+    }
+
     return CallToolResult(
       content: [
         TextContent(

--- a/lib/src/inspector/tools/reload_tool.dart
+++ b/lib/src/inspector/tools/reload_tool.dart
@@ -34,11 +34,17 @@ class ReloadTool extends InspectorTool {
     ToolContext context,
   ) async {
     final session = context.activeSession;
-    if (session == null) return context.noActiveSession();
+    if (session == null) {
+      return context.noActiveSession();
+    }
 
     final bool fullRestart =
         coerceBool(request.arguments!['full_restart']) ?? false;
+
     try {
+      // Start a reload / restart timer.
+      session.reloadTimer = Stopwatch()..start();
+
       await session.restart(fullRestart: fullRestart);
     } on DaemonException catch (e) {
       return CallToolResult(
@@ -48,14 +54,6 @@ class ReloadTool extends InspectorTool {
     }
 
     final String action = fullRestart ? 'Hot restart' : 'Hot reload';
-
-    if (session.hasCompanion) {
-      // TODO: This may be too early to call 'log'. Consider delaying it until
-      // we know the companion package is available.
-      session.serviceExtensions?.slipstreamLog(
-        fullRestart ? 'restart' : 'reload',
-      );
-    }
 
     return CallToolResult(
       content: [

--- a/lib/src/inspector/tools/take_screenshot_tool.dart
+++ b/lib/src/inspector/tools/take_screenshot_tool.dart
@@ -54,7 +54,11 @@ class TakeScreenshotTool extends InspectorTool {
       if (session.hasCompanion) {
         overlaysDisabled = false;
         await extensions!.slipstreamOverlays(enabled: true);
-        extensions.slipstreamLog('screenshot');
+        extensions.slipstreamLog(
+          'screenshot',
+          kind: 'screenshot',
+          viz: 'flash',
+        );
       }
       return CallToolResult(
         content: [ImageContent(data: base64Data, mimeType: 'image/png')],

--- a/lib/src/inspector/tools/take_screenshot_tool.dart
+++ b/lib/src/inspector/tools/take_screenshot_tool.dart
@@ -41,14 +41,29 @@ class TakeScreenshotTool extends InspectorTool {
 
     final pixelRatio = coerceDouble(request.arguments!['pixel_ratio']);
 
+    final extensions = session.serviceExtensions;
+    bool overlaysDisabled = false;
     try {
+      if (session.hasCompanion) {
+        await extensions!.slipstreamOverlays(enabled: false);
+        overlaysDisabled = true;
+      }
       final String base64Data = await session.takeScreenshot(
         maxPixelRatio: pixelRatio,
       );
+      if (session.hasCompanion) {
+        overlaysDisabled = false;
+        await extensions!.slipstreamOverlays(enabled: true);
+        extensions.slipstreamLog('screenshot');
+      }
       return CallToolResult(
         content: [ImageContent(data: base64Data, mimeType: 'image/png')],
       );
     } on RPCError catch (e) {
+      // Restore overlays even on failure.
+      if (overlaysDisabled) {
+        extensions!.slipstreamOverlays(enabled: true).ignore();
+      }
       return context.rpcError(e);
     }
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -42,3 +42,17 @@ Object? jsonTryParse(String source) {
     return null;
   }
 }
+
+/// Describe a short duration. This may return '100ms' or it may return '6.1s'.
+String? describeShortDuration(Duration? elapsed) {
+  if (elapsed == null) return null;
+
+  final ms = elapsed.inMilliseconds;
+
+  if (ms < 1000) {
+    return '${ms}ms';
+  } else {
+    final s = ms / 1000.0;
+    return '${s.toStringAsFixed(1)}s';
+  }
+}

--- a/test/inspector/semantics_formatter_test.dart
+++ b/test/inspector/semantics_formatter_test.dart
@@ -105,7 +105,7 @@ void main() {
   group('formatSemanticsTree', () {
     SemanticNode node({
       int id = 1,
-      String role = '',
+      String? role,
       String label = '',
       String value = '',
       String hint = '',

--- a/tool/inspector_integration_test.dart
+++ b/tool/inspector_integration_test.dart
@@ -15,7 +15,7 @@ import '../test/test_utils.dart';
 //
 // For the moment this script is run manually.
 
-// TODO: complete the test coverage for the commands
+// TODO: Complete test coverage for the commands.
 
 void main(List<String> args) {
   // Require the app to run as the first arg.
@@ -37,11 +37,6 @@ void main(List<String> args) {
   });
 
   tearDownAll(() async {
-    // TODO: Sombody else is closing the app for us...
-    // await env.serverConnection.callTool(
-    //   CallToolRequest(name: 'close_app'),
-    // );
-
     await env.shutdown();
   });
 


### PR DESCRIPTION
Wires up the `ext.slipstream.log` and `ext.slipstream.overlays` companion extensions across the MCP server.

- `slipstreamLog(command, {details, kind, finder, finderValue, viz})` — logs agent commands to the ghost overlay; best-effort, never throws
- `slipstreamOverlays({required bool enabled})` — hides/restores managed overlays (debug banner); best-effort
- `reload`/`restart`: timed via `Stopwatch` on `AppSession`; hot restart defers the log until `ext.slipstream.ping` re-registers after the new isolate boots
- `take_screenshot`: hides overlays before capture, restores after (including on error), logs with `viz: "flash"`
- `evaluate`, `inspect_layout`, `perform_semantic_action`: log with appropriate `kind` and `viz` values
- `SemanticNode.role` changed to `String?` (null for plain text/containers)
- App session VM service subscription split into separate isolate + extension streams; `kServiceExtensionAdded` used to detect companion re-ping after hot restart