### PR TITLE
Prep for 1.1.0 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Flutter/Dart agent tooling: package API summarization and runtime UI introspection.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# Changelog
+## 1.1.0
+
+### `slipstream_agent` companion integration improvements
+
+When `package:slipstream_agent` is installed in the target app, inspector tools
+now report their activity to the companion's ghost overlay:
+
+- `take_screenshot` suppresses the Flutter debug banner before capture and
+  restores it afterward (via `ext.slipstream.overlays`)
+- `reload` and hot restart log the operation with elapsed time
+- `evaluate`, `inspect_layout`, and `perform_semantic_action` log their
+  invocations with relevant context (expression snippet, widget ID, action
+  target)
+- Hot restart timing is handled correctly: the log fires after the companion
+  re-registers its extensions post-restart
 
 ## 1.0.0
 
@@ -8,8 +22,8 @@ Initial public release.
 
 - Warns when an agent adds a discontinued package (with official replacement if
   one is listed)
-- Warns when a constraint targets an older major version than the current pub.dev
-  release
+- Warns when a constraint targets an older major version than the current
+  pub.dev release
 - Warns when a package name is not found on pub.dev
 - Fires on `flutter pub add` / `dart pub add` and on direct `pubspec.yaml` edits
 - Always exits 0 — advisory only, never hard-blocks
@@ -24,8 +38,8 @@ Initial public release.
 
 ### `inspector` MCP server
 
-- `run_app` — builds and launches a Flutter app; auto-selects the best
-  available device (desktop > simulator > emulator > physical > web)
+- `run_app` — builds and launches a Flutter app; auto-selects the best available
+  device (desktop > simulator > emulator > physical > web)
 - `reload` — hot reload or hot restart
 - `take_screenshot` — PNG screenshot via the inspector protocol
 - `inspect_layout` — widget layout tree (subtree depth configurable)

--- a/docs/feedback-05.md
+++ b/docs/feedback-05.md
@@ -1,0 +1,61 @@
+# Feedback: Flutter Slipstream Smoke Test
+
+## Work Log
+
+1. **Packages Test**:
+   - Used `package_summary` on `provider`. Correctly identified public libraries
+     and exported names.
+   - Used `library_stub` on `package:provider/provider.dart`. Got a
+     comprehensive list of signatures.
+   - Used `class_stub` on `MultiProvider`. Successfully drilled into the
+     specific class API.
+2. **Inspector Test**:
+   - Launched app using `run_app`.
+   - Navigated between tabs using `perform_tap` and `navigate`. Verified with
+     `get_route` and `take_screenshot`.
+   - Attempted to set text in a `TextField` using `perform_set_text` with
+     `bySemanticsLabel`. It failed to find the element despite `get_semantics`
+     showing the label.
+   - Successfully set text using `perform_semantic_action` with `setText` and
+     the `node_id`.
+   - Evaluated a Dart expression using `evaluate`. Note: `context` is not in
+     scope by default.
+   - Inspected layout with `inspect_layout`.
+   - Performed a scroll with `perform_scroll`.
+   - Modified `lib/main.dart` and used `reload`. Verified the UI change with
+     `take_screenshot`.
+   - Closed the app with `close_app`.
+
+## Pros
+
+- **Packages Server**: The stubs are very clean and provide exactly what an
+  agent needs to understand a package API without reading implementation
+  details.
+- **Inspector Server**: `take_screenshot` is invaluable for visual verification.
+  `get_route` handles nested navigators well. `reload` is fast and reliable.
+- **`perform_scroll` / `perform_scroll_until_visible`**: Successfully scrolled
+  the `ListView`. However, `get_semantics` on macOS did not show
+  `scrollUp`/`scrollDown` actions on the nodes, which might be a
+  platform-specific difference in semantics reporting.
+- **Integration**: The tools feel well-integrated into the Flutter development
+  workflow.
+
+## Cons / Issues
+
+- **`perform_set_text` / `perform_tap` with `bySemanticsLabel`**: Failed to find
+  the widget even when the label was present in `get_semantics`. Using `node_id`
+  is a reliable workaround but `bySemanticsLabel` should ideally work.
+- **Evaluation Scope**: Lack of `context` in `evaluate` makes it harder to query
+  widget-specific state without knowing exactly where to look in global
+  bindings.
+
+## Suggestions for Improvement
+
+- **Evaluation Helpers**: Provide a way to evaluate expressions with a `context`
+  (perhaps by providing a widget ID or a common finder).
+- **Semantics Finder Robustness**: Investigate why `bySemanticsLabel` failed in
+  some cases. It might be due to how the label is matched (exact match vs.
+  substring).
+- **Documentation**: Explicitly mention in `evaluate` documentation that
+  `context` is not available and suggest alternatives for common tasks (like
+  using `WidgetsBinding`).

--- a/docs/study-setup.md
+++ b/docs/study-setup.md
@@ -54,9 +54,9 @@ Do you have any questions before you begin?
 ## Gemini
 
 Hi! We're testing out new coding agent tooling in the form of two MCP servers,
-'slipstream-inspector' and 'slipstream-packages'. The general tool is Flutter
-Slipstream: "A tool that makes AI coding agents more effective for Dart and
-Flutter projects.".
+'inspector' and 'packages'. The general tool is Flutter Slipstream /
+flutter-slipstream: "A tool that makes AI coding agents more effective for Dart
+and Flutter projects.".
 
 Your job is to test the tool - learn what it does well and where it could
 improve - and provide feedback about it. Please familiarize yourself with its
@@ -69,10 +69,9 @@ iteratively - turn it into a working Flutter app.
   tool's features.
 - Have a theme toggle.
 - Use a Scaffold and a drawer.
-- Use a bottom navigation bar.
-- In one page of the navigation bar include a very small widget showcase.
-- In another, include a Mondrian art page.
-- In another, include a small game (tic tac toe? something else?).
+- Use a bottom navigation bar with several pages.
+- For each page, have a set of components that together form a very small widget
+  showcase.
 
 Building the app is a mechanism for testing this tool. You can assume a mobile
 phone target / mobile phone screen dimensions.
@@ -82,5 +81,24 @@ hot reload at regular intervals. You should work independently; if you get stuck
 skip the section you're working on. Once you're done, please write your
 feedback - pros, cons, bugs, and things which could improve the tool - as well
 as a work log - to 'feedback.md' in the current directory.
+
+Do you have any questions before you begin?
+
+## Smoke test
+
+Hi! We're testing out new coding agent tooling in the form of two MCP servers,
+'inspector' and 'packages'. The general tool is Flutter Slipstream /
+flutter-slipstream: "A tool that makes AI coding agents more effective for Dart
+and Flutter projects.".
+
+Your job is to smoke test the tool - to use tools from each MCP server in a
+roughly typical workflow for developers. We want to catch any broad regressions
+in the tool as well as any minor issues or usability rough spots. You can use
+the app in the current directory as part of your testing.
+
+Early in your work please start the app. You should work independently; if you
+get stuck skip the section you're working on. Once you're done, please write
+your feedback - pros, cons, bugs, and things which could improve the tool - as
+well as a work log - to 'feedback.md' in the current directory.
 
 Do you have any questions before you begin?

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Flutter/Dart agent tooling: package API summarization and runtime UI introspection.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",


### PR DESCRIPTION
Prep commit for the 1.1.0 release.

- Update changelog for 1.1.0 (companion overlay integration improvements)
- Bump version to 1.1.0 in `plugin.json` and `gemini-extension.json`
- Add smoke test prompt to `docs/study-setup.md`
- Add `docs/feedback-05.md` from smoke test session

🤖 Generated with [Claude Code](https://claude.com/claude-code)