### PR TITLE
Add get_output tool for pull-based app output retrieval

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flutter/Dart agent tooling: package API summarization and runtime UI introspection.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## 1.2.0-wip
+## 1.2.0
 
 - Addressed an issue where a 'restart' message could appear in the app under
   test at startup (and not just after a hot restart).
+- Added `get_output` tool: returns buffered app stdout, Flutter errors, and
+  route changes since the last call (or the last reload/restart), then clears
+  the buffer. Replaces push-based MCP log notifications, which are not forwarded
+  to agent context in Claude Code or Gemini CLI.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0-wip
+
+- Addressed an issue where a 'restart' message could appear in the app under
+  test at startup (and not just after a hot restart).
+
 ## 1.1.0
 
 ### `slipstream_agent` companion integration improvements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ before launching.
   absolute path
 - `reload` — hot reload (`full_restart: false`, default) or hot restart
   (`full_restart: true`)
+- `get_output` — drains the output buffer; call after reload and interaction
+  tools to see app stdout, Flutter errors, and route changes
 - `take_screenshot` — captures a PNG screenshot via the inspector protocol
 - `inspect_layout` — returns the widget layout tree; `widget_id` omitted → root
 - `evaluate` — evaluates an arbitrary Dart expression on the main isolate
@@ -95,7 +97,8 @@ tool code.
   `class_stub` all implemented
 - inspector MCP server: functional — all tools above implemented and working
 - `slipstream_agent` companion detection and event forwarding: implemented
-- Flutter.Error events are pushed to agents as MCP log warnings with widget IDs
+- `get_output` tool: pull-based output buffer for app stdout, Flutter errors,
+  and route changes; `_serverLog` is diagnostic-only (not agent-visible)
 
 ## Development
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,27 +1,32 @@
 # Flutter Slipstream Extension
 
 This extension provides tools for Dart/Flutter development:
-- **`packages` MCP server**: Token-efficient package API summarization from `.pub-cache`.
-- **`inspector` MCP server**: Runtime UI inspection and interaction for Flutter apps.
+
+- **`packages` MCP server**: Token-efficient package API summarization from
+  `.pub-cache`.
+- **`inspector` MCP server**: Runtime UI inspection and interaction for Flutter
+  apps.
 
 ## `packages` Workflow
+
 1. Use `package_summary` to identify public libraries and exported names.
 2. Use `library_stub` to get full API signatures for a library.
-3. Use `class_stub` to drill into specific classes when needed.
-*This avoids reading large implementation files and provides accurate signatures.*
+3. Use `class_stub` to drill into specific classes when needed. _This avoids
+   reading large implementation files and provides accurate signatures._
 
 ## `inspector` Workflow
+
 1. **Launch**: `run_app` to start the Flutter app.
 2. **Iterate**:
    - Edit source files.
    - `reload` (hot reload) to apply changes.
    - `take_screenshot` to visually confirm.
 3. **Debug**:
-   - `inspect_layout` for layout/overflow issues (use widget IDs from `flutter.error` logs).
+   - `inspect_layout` for layout/overflow issues (use widget IDs from
+     `flutter.error` logs).
    - `get_route` to see the current screen stack.
    - `get_semantics` to find interactive elements by label or ID.
    - `evaluate` for runtime state (e.g., `MediaQuery`).
-4. **Interact**: Use `perform_tap`, `perform_set_text`, `perform_scroll`, or `perform_navigate`.
+4. **Interact**: Use `perform_tap`, `perform_set_text`, `perform_scroll`, or
+   `perform_navigate`.
 5. **Finish**: `close_app` to release resources.
-
-*Flutter.Error events are automatically logged with widget IDs to help diagnose issues.*

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ expressions, and observe runtime errors with widget IDs.
 |---------|-------------|
 | `run_app` | Builds and launches the Flutter app. |
 | `reload` | Applies source file changes to a running Flutter app. |
+| `get_output` | Returns buffered app output and runtime events since the last call (or the last reload/restart). |
 | `take_screenshot` | Captures a PNG screenshot of the running Flutter app. |
 | `inspect_layout` | Use when debugging layout issues, overflow errors, or unexpected widget sizing. |
 | `evaluate` | Evaluates a Dart expression on the running app's main isolate and returns the result as a string. |

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -34,16 +34,21 @@
       `3` is not of type `int` at path #root["subtree_depth"]"; Same pattern as
       the `node_id` issue above — likely the same underlying schema problem.
 
-### How-to
+## How-to
 
 - adding semantic nodes helps traversal (and also screen readers, ...)
 - modifying the source to improve getting and setting routes?
-- ship a small 'agents tools' library?
-  - it could add vm service extension methods which we could then call
-  - improved semantic node traversal
 
-- [ ] explore what a guide to agents adding 'assists' to the code would look
-      like (semantic nodes; something to aide navigation?)
 - [x] explore what an in-line package could provide; would it be a big enough
       win to recommend it? better semantic tree retrieval, better routing
       support, ...; package:slipstream_agent / package:slipstream_support
+
+## Logging
+
+- Claude Code does not appear to forward notifications/message MCP events into
+  the model context at all.
+- Once we do get log messages to the model we should make sure they're not too
+  verbose.
+
+- [ ] resolution: design and add an 'output' tool; get most recent stdout and
+      errors

--- a/docs/slipstream_doc.md
+++ b/docs/slipstream_doc.md
@@ -96,7 +96,7 @@ Recommended workflow for UI changes:
 Debugging layout issues:
 
 - inspect_layout with no widget_id starts from the root.
-- Widget IDs appear in flutter.error log events — use them to jump directly to
+- Widget IDs appear in flutter.error log output — use them to jump directly to
   the failing widget.
 - Increase subtree_depth to see deeper into the tree.
 
@@ -112,8 +112,8 @@ Orientation:
   instead of 'perform_semantic_action' — these support byKey/byType/byText
   finders and do not require semantics annotations.
 
-Flutter.Error events are forwarded automatically as MCP log warnings — no
-polling needed. They include widget IDs for use with inspect_layout.
+After reload or any interaction tool, call get_output to see app stdout, Flutter
+errors, and route changes since the last call.
 
 ### `inspector:run_app`
 
@@ -149,6 +149,26 @@ be fully reset.
 
 - `full_restart`: If true, performs a hot restart instead of a hot reload.
   Defaults to false.
+
+### `inspector:get_output`
+
+```
+get_output()
+```
+
+Returns buffered app output and runtime events since the last call (or the last
+reload/restart).
+
+Call this after reload, after interaction tools (perform_tap, perform_set_text,
+etc.), and after run_app to check for errors or unexpected output. Calling this
+clears the buffer.
+
+Output is prefixed by source:
+
+- [app] print() / debugPrint() output from the app
+- [stdout] other process stdout
+- [flutter.error] framework errors; widget IDs usable with inspect_layout
+- [route] navigation events (requires slipstream_agent companion)
 
 ### `inspector:take_screenshot`
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flutter/Dart agent tooling: package API summarization and runtime UI introspection.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/lib/src/inspector/app_session.dart
+++ b/lib/src/inspector/app_session.dart
@@ -451,7 +451,9 @@ class AppSession {
   // stopped the timer, and we're only called here after the companion agent
   // has become available.
   void _checkHotRestartTimer() {
-    final duration = reloadTimer?.elapsed;
+    if (reloadTimer == null) return;
+
+    final duration = reloadTimer!.elapsed;
     reloadTimer = null;
 
     serviceExtensions?.slipstreamLog(

--- a/lib/src/inspector/app_session.dart
+++ b/lib/src/inspector/app_session.dart
@@ -75,10 +75,6 @@ class AppSession {
   // ignore: unused_field
   String? _dtdToolsUri;
 
-  /// Framework errors received via the `Flutter.Error` VM service event since
-  /// the session started or the last hot restart.
-  List<FlutterError> get errors => List.unmodifiable(_errors);
-
   /// Appends a prefixed line to the output buffer.
   void addOutput(String prefix, String line) {
     final pre = '[$prefix] ';

--- a/lib/src/inspector/app_session.dart
+++ b/lib/src/inspector/app_session.dart
@@ -23,7 +23,7 @@ class AppSession {
     this._process,
     this._eventListener, {
     this.deviceId,
-    required this.debugLog,
+    required this.serverLog,
   }) {
     _process.stdout
         .transform(utf8.decoder)
@@ -41,7 +41,7 @@ class AppSession {
   /// The 'flutter run' device ID that we launched on.
   final String? deviceId;
 
-  final DebugLogger debugLog;
+  final DebugLogger serverLog;
 
   // Used to time reload / restart operations.
   Stopwatch? reloadTimer;
@@ -66,6 +66,9 @@ class AppSession {
   static const int _maxErrors = 50;
   final List<FlutterError> _errors = [];
 
+  // Output buffer — prefixed lines accumulated since the last drain or reload.
+  final List<String> _outputBuffer = [];
+
   // ignore: unused_field
   String? _devToolsUri;
 
@@ -75,6 +78,21 @@ class AppSession {
   /// Framework errors received via the `Flutter.Error` VM service event since
   /// the session started or the last hot restart.
   List<FlutterError> get errors => List.unmodifiable(_errors);
+
+  /// Appends a prefixed line to the output buffer.
+  void addOutput(String prefix, String line) {
+    final pre = '[$prefix] ';
+    line = line.trimRight();
+    line = line.replaceAll('\n', '\n  ');
+    _outputBuffer.addAll('$pre$line'.split('\n'));
+  }
+
+  /// Returns all buffered output lines and clears the buffer.
+  List<String> drainOutput() {
+    final lines = List<String>.from(_outputBuffer);
+    _outputBuffer.clear();
+    return lines;
+  }
 
   /// Whether the slipstream_agent companion package is installed in the running
   /// app.
@@ -108,7 +126,7 @@ class AppSession {
     required EventCallback eventListener,
     String? deviceId,
     String? target,
-    required DebugLogger debugLog,
+    required DebugLogger serverLog,
   }) async {
     deviceId ??= await _autoSelectDevice(workingDirectory);
 
@@ -129,7 +147,7 @@ class AppSession {
       process,
       eventListener,
       deviceId: deviceId,
-      debugLog: debugLog,
+      serverLog: serverLog,
     );
     await session._startedCompleter.future;
     return session;
@@ -298,6 +316,7 @@ class AppSession {
       throw DaemonException('app.restart failed (code $code): $message');
     }
     _errors.clear();
+    _outputBuffer.clear();
   }
 
   /// Stops the running app.

--- a/lib/src/inspector/inspector_mcp.dart
+++ b/lib/src/inspector/inspector_mcp.dart
@@ -7,6 +7,7 @@ import 'app_session.dart';
 import 'tool_context.dart';
 import 'tools/close_app_tool.dart';
 import 'tools/evaluate_tool.dart';
+import 'tools/get_output_tool.dart';
 import 'tools/get_route_tool.dart';
 import 'tools/get_semantics_tool.dart';
 import 'tools/inspect_layout_tool.dart';
@@ -28,9 +29,13 @@ base class InspectorMCPServer extends MCPServer
     with ToolsSupport, LoggingSupport {
   static const String _loggerId = 'flutter_agent_tools';
 
-  late final ToolContext _context = ToolContext(
-    log: (level, message) => log(level, message, logger: _loggerId),
-  );
+  late final ToolContext _context = ToolContext(log: _serverLog);
+
+  /// Diagnostic log — sent as an MCP notification (not buffered for agents).
+  /// Use for internal server events; not expected to reach the model context.
+  void _serverLog(String message) {
+    log(LoggingLevel.info, message, logger: _loggerId);
+  }
 
   InspectorMCPServer(super.channel)
     : super.fromStreamChannel(
@@ -51,7 +56,7 @@ Recommended workflow for UI changes:
 
 Debugging layout issues:
 - inspect_layout with no widget_id starts from the root.
-- Widget IDs appear in flutter.error log events — use them to jump directly to the failing widget.
+- Widget IDs appear in flutter.error log output — use them to jump directly to the failing widget.
 - Increase subtree_depth to see deeper into the tree.
 
 Orientation:
@@ -59,7 +64,7 @@ Orientation:
 - get_semantics lists visible, interactive nodes with their IDs. Pass node IDs directly to 'perform_semantic_action'.
 - If the app has slipstream_agent installed, use 'perform_tap', 'perform_set_text', 'perform_scroll', or 'perform_scroll_until_visible' instead of 'perform_semantic_action' — these support byKey/byType/byText finders and do not require semantics annotations.
 
-Flutter.Error events are forwarded automatically as MCP log warnings — no polling needed. They include widget IDs for use with inspect_layout.''',
+After reload or any interaction tool, call get_output to see app stdout, Flutter errors, and route changes since the last call.''',
       ) {
     loggingLevel = LoggingLevel.info;
 
@@ -90,6 +95,7 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
       ),
     );
     register(ReloadTool());
+    register(GetOutputTool());
     register(TakeScreenshotTool());
     register(InspectLayoutTool());
     register(EvaluateTool());
@@ -127,33 +133,32 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
   void _handleEvent(AppEvent event) {
     if (event.event == 'app.stop') {
       _context.removeSession();
-
-      log(
-        LoggingLevel.info,
-        'App stopped; session released.',
-        logger: _loggerId,
-      );
+      _serverLog('App stopped; session released.');
       return;
-    } else if (event.event == 'slipstream.windowResized') {
+    }
+
+    final session = _context.activeSession;
+
+    if (event.event == 'slipstream.windowResized') {
       final p = event.params;
       final double w = (p['logicalWidth'] as num?)?.toDouble() ?? 0;
       final double h = (p['logicalHeight'] as num?)?.toDouble() ?? 0;
       final double dpr = (p['devicePixelRatio'] as num?)?.toDouble() ?? 1;
-      log(
-        LoggingLevel.info,
+      _serverLog(
         '[window] ${w.toStringAsFixed(0)}×${h.toStringAsFixed(0)} logical px '
         '(dpr=${dpr.toStringAsFixed(1)})',
-        logger: _loggerId,
       );
       return;
     } else if (event.event == 'slipstream.routeChanged') {
       final String path = event.params['path'] as String? ?? '?';
-      log(LoggingLevel.info, '[route] $path', logger: _loggerId);
+      session?.addOutput('route', path);
+      _serverLog('[route] $path');
       return;
     } else if (event.event == 'flutter.error') {
       final String summary =
           event.params['summary'] as String? ?? 'Unknown Flutter error';
-      log(LoggingLevel.warning, '[flutter.error] $summary', logger: _loggerId);
+      session?.addOutput('flutter.error', summary);
+      _serverLog('[flutter.error] $summary');
       return;
     }
 
@@ -161,19 +166,23 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
     if (item != null) {
       if (event.event == 'app.log') {
         const appOutputPrefix = 'flutter: ';
-        if (item.$2.startsWith(appOutputPrefix)) {
-          final msg = item.$2.substring(appOutputPrefix.length);
-          log(item.$1, '[app] $msg', logger: _loggerId);
+        final String line;
+        if (item.startsWith(appOutputPrefix)) {
+          line = item.substring(appOutputPrefix.length);
+          session?.addOutput('app', line);
+          _serverLog('[app] $line');
         } else {
-          log(item.$1, '[stdout] ${item.$2}', logger: _loggerId);
+          line = item;
+          session?.addOutput('stdout', line);
+          _serverLog('[stdout] $line');
         }
       } else {
-        log(item.$1, '[${event.event}] ${item.$2}', logger: _loggerId);
+        _serverLog('[${event.event}] $item');
       }
     }
   }
 
-  (LoggingLevel, String)? _convertToLog(AppEvent event) {
+  String? _convertToLog(AppEvent event) {
     final Map<String, dynamic> params = event.params;
 
     String message = params.keys
@@ -187,8 +196,7 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
       case 'app.log':
         {
           message = params['log'] as String? ?? message;
-          final bool isError = params['error'] as bool? ?? false;
-          return (isError ? LoggingLevel.warning : LoggingLevel.info, message);
+          return message;
         }
       case 'app.progress':
         {
@@ -205,6 +213,6 @@ Flutter.Error events are forwarded automatically as MCP log warnings — no poll
         }
     }
 
-    return (LoggingLevel.info, message);
+    return message;
   }
 }

--- a/lib/src/inspector/tool_context.dart
+++ b/lib/src/inspector/tool_context.dart
@@ -35,7 +35,7 @@ class ToolContext {
   AppSession? _session;
 
   /// Logs a message at the given level to the MCP client.
-  final void Function(LoggingLevel level, String message) log;
+  final void Function(String message) log;
 
   /// The currently active app session, or null if no app is running.
   AppSession? get activeSession => _session;

--- a/lib/src/inspector/tools/get_output_tool.dart
+++ b/lib/src/inspector/tools/get_output_tool.dart
@@ -1,0 +1,95 @@
+import 'package:dart_mcp/server.dart';
+
+import '../tool_context.dart';
+
+/// Implements the `get_output` MCP tool.
+///
+/// Returns buffered app output and runtime events since the last call (or
+/// since the last reload/restart, whichever is more recent), then clears the
+/// buffer. Agents should call this after `reload`, after interaction tools
+/// (`perform_tap`, `perform_set_text`, etc.), and after `run_app` to see
+/// what the app has printed and whether any errors occurred.
+///
+/// ## Buffer contents
+///
+/// The buffer accumulates the following in order of occurrence:
+///
+/// - **App stdout** — anything the app prints via `print()` or `debugPrint()`,
+///   prefixed `[app]`. Non-`flutter:` stdout (e.g. from native code) is
+///   prefixed `[stdout]`.
+/// - **Flutter errors** — uncaught framework errors with a one-line summary
+///   and widget ID, prefixed `[flutter.error]`. Widget IDs can be passed
+///   directly to `inspect_layout`.
+/// - **Route changes** — navigation events from the slipstream_agent companion,
+///   prefixed `[route]`. Only present when the companion is installed with a
+///   router adapter.
+/// - **Window resize** — logical size changes, prefixed `[window]`. Only
+///   present when the companion is installed.
+///
+/// ## Reset behaviour
+///
+/// The buffer is cleared:
+/// - After each `get_output` call (this call).
+/// - On hot reload and hot restart.
+/// - On `run_app` (new session).
+///
+/// ## Example output
+///
+/// ```
+/// [app] Loading podcast feed…
+/// [app] Loaded 42 episodes.
+/// [flutter.error] RenderFlex overflowed by 32px (widget id: inspector-12)
+/// [route] /podcast/abc123
+/// ```
+///
+/// An empty result means no output has been produced since the last reset.
+class GetOutputTool extends InspectorTool {
+  @override
+  final Tool definition = Tool(
+    name: 'get_output',
+    description:
+        'Returns buffered app output and runtime events since the last call '
+        '(or the last reload/restart).\n\n'
+        'Call this after reload, after interaction tools (perform_tap, '
+        'perform_set_text, etc.), and after run_app to check for errors or '
+        'unexpected output. Calling this clears the buffer.\n\n'
+        'Output is prefixed by source:\n'
+        '- [app] print() / debugPrint() output from the app\n'
+        '- [stdout] other process stdout\n'
+        '- [flutter.error] framework errors; widget IDs usable with inspect_layout\n'
+        '- [route] navigation events (requires slipstream_agent companion)',
+    inputSchema: Schema.object(properties: {}, required: []),
+  );
+
+  @override
+  Future<CallToolResult> handle(
+    CallToolRequest request,
+    ToolContext context,
+  ) async {
+    final session = context.activeSession;
+    if (session == null) return context.noActiveSession();
+
+    final lines = session.drainOutput();
+    final text = lines.isEmpty ? '(no output)' : lines.join('\n');
+
+    if (session.hasCompanion) {
+      final extensions = session.serviceExtensions!;
+
+      // "get output: 7 lines, 1 error"
+      var msg = '∅';
+      if (lines.isNotEmpty) {
+        msg = lines.length == 1 ? '1 line' : '${lines.length} lines';
+        final errors =
+            lines.where((line) => line.startsWith('[flutter.error]')).length;
+        if (errors != 0) {
+          final errDesc = errors == 1 ? '1 error' : '$errors errors';
+          msg = '$msg, $errDesc';
+        }
+      }
+
+      extensions.slipstreamLog('get output', kind: 'read', details: msg);
+    }
+
+    return CallToolResult(content: [TextContent(text: text)]);
+  }
+}

--- a/lib/src/inspector/tools/run_app_tool.dart
+++ b/lib/src/inspector/tools/run_app_tool.dart
@@ -84,7 +84,7 @@ class RunAppTool extends InspectorTool {
         eventListener: eventListener,
         deviceId: device,
         target: target,
-        debugLog: (message) => context.log(LoggingLevel.info, message),
+        serverLog: context.log,
       );
       await registerSession(session);
     } on DaemonException catch (e) {

--- a/lib/src/inspector/tools/run_app_tool.dart
+++ b/lib/src/inspector/tools/run_app_tool.dart
@@ -26,9 +26,8 @@ class RunAppTool extends InspectorTool {
     description:
         'Builds and launches the Flutter app. Call this first before '
         'inspecting, screenshotting, or evaluating. If an app is already '
-        'running it is stopped and replaced. Flutter.Error events from the '
-        'running app are automatically forwarded as MCP log warnings — no '
-        'polling needed.',
+        'running it is stopped and replaced. Call get_output after run_app '
+        'to see initial app output and any startup errors.',
     inputSchema: Schema.object(
       properties: {
         'working_directory': Schema.string(

--- a/lib/src/shorthand/packages_mcp.dart
+++ b/lib/src/shorthand/packages_mcp.dart
@@ -32,6 +32,8 @@ Typical call sequence:
 Source is the local pub cache — already downloaded, always matches the resolved
 version in pubspec.lock, no network required.''',
       ) {
+    loggingLevel = LoggingLevel.info;
+
     _registerTools();
   }
 


### PR DESCRIPTION
Replaces push-based MCP log notifications (not forwarded to agent context in Claude Code or Gemini CLI) with a pull-based `get_output` tool that agents drain on demand.

- `AppSession._outputBuffer` accumulates prefixed lines (`[app]`, `[stdout]`, `[flutter.error]`, `[route]`); cleared on reload/restart and each `get_output` call
- `get_output` drains the buffer; logs a summary to the companion overlay when present
- `_serverLog` simplified to diagnostic-only (not agent-visible); `ToolContext.log` updated to match
- `run_app` description updated to reference `get_output`; stale MCP log warning text removed throughout
- Version bumped to 1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)