### PR TITLE
Add shell script tests and switch deps_check to package:args

### DIFF
--- a/bin/deps_check.dart
+++ b/bin/deps_check.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:flutter_slipstream/src/deps/deps_check.dart';
 
 /// PreToolUse hook: validates Dart/Flutter package additions against pub.dev.
@@ -12,14 +13,21 @@ import 'package:flutter_slipstream/src/deps/deps_check.dart';
 /// Reads tool input JSON from stdin. Always exits 0 (warnings only — the
 /// agent decides whether to proceed).
 void main(List<String> args) async {
-  final String mode;
-  if (args.contains('--mode=pub-add')) {
-    mode = 'pub-add';
-  } else if (args.contains('--mode=pubspec-guard')) {
-    mode = 'pubspec-guard';
-  } else {
+  final parser =
+      ArgParser()..addOption('mode', allowed: ['pub-add', 'pubspec-guard']);
+
+  final ArgResults results;
+  try {
+    results = parser.parse(args);
+  } on ArgParserException catch (e) {
+    stderr.writeln('deps_check: ${e.message}');
+    exit(0); // Fail open.
+  }
+
+  final String? mode = results['mode'] as String?;
+  if (mode == null) {
     stderr.writeln(
-      'deps_check: unknown mode. Pass --mode=pub-add or --mode=pubspec-guard',
+      'deps_check: --mode is required. Pass --mode=pub-add or --mode=pubspec-guard',
     );
     exit(0); // Fail open.
   }
@@ -44,4 +52,8 @@ void main(List<String> args) async {
   } else {
     await handlePubspecGuard(input);
   }
+
+  // We call `exit` explicitly here in case any network calls - to pub? - would
+  // otherwise delay exit.
+  exit(0);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -18,7 +18,7 @@ packages:
     source: hosted
     version: "12.1.0"
   args:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 
 dependencies:
   analyzer: ^12.0.0
+  args: ^2.7.0
   collection: ^1.19.0
   dart_mcp: ^0.5.0
   http: ^1.6.0

--- a/scripts/deps_check.sh
+++ b/scripts/deps_check.sh
@@ -27,5 +27,15 @@ if [[ "$*" == *"--mode=pub-add"* ]]; then
   exit 0
 fi
 
+if [[ "$*" == *"--mode=pubspec-guard"* ]]; then
+  INPUT=$(cat)
+  if ! printf '%s' "$INPUT" | grep -qF 'pubspec.yaml'; then
+    exit 0
+  fi
+  if ! command -v dart &>/dev/null; then exit 0; fi
+  printf '%s' "$INPUT" | (cd "$PLUGIN_ROOT" && exec dart run "bin/deps_check.dart" "$@")
+  exit 0
+fi
+
 if ! command -v dart &>/dev/null; then exit 0; fi
 (cd "$PLUGIN_ROOT" && exec dart run "bin/deps_check.dart" "$@")

--- a/test/scripts/deps_check_sh_test.dart
+++ b/test/scripts/deps_check_sh_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+final _scriptPath = path.join(Directory.current.path, 'scripts/deps_check.sh');
+
+/// Runs deps_check.sh with [mode] and [stdin], returning (exitCode, stdout).
+///
+/// The Dart behavior is covered by unit tests; these tests focus on whether
+/// the shell script correctly fast-exits (filtered) or reaches the Dart
+/// invocation (pass-through).
+Future<({int exitCode, String stdout})> runScript(
+  String mode,
+  String stdin,
+) async {
+  final process = await Process.start('bash', [_scriptPath, '--mode=$mode']);
+  try {
+    process.stdin.write(stdin);
+    await process.stdin.close();
+  } catch (_) {
+    // The script may exit before reading stdin (fast-exit path); ignore.
+  }
+
+  final out = await process.stdout.transform(utf8.decoder).join();
+  await process.stderr.drain<void>();
+  final exitCode = await process.exitCode;
+
+  return (exitCode: exitCode, stdout: out);
+}
+
+// Minimal tool-input JSON wrappers.
+String pubAddInput(String command) => jsonEncode({
+  'tool_input': {'command': command},
+});
+
+String editInput(String filePath) => jsonEncode({
+  'tool_input': {'file_path': filePath, 'old_string': '', 'new_string': ''},
+});
+
+void main() {
+  group('deps_check.sh --mode=pub-add', () {
+    test(
+      'filtered: non-pub-add bash command exits immediately with no output',
+      () async {
+        final r = await runScript('pub-add', pubAddInput('dart pub get'));
+        expect(r.exitCode, 0);
+        expect(r.stdout, isEmpty);
+      },
+    );
+
+    test('pass-through: pub add command reaches Dart and exits 0', () async {
+      // The Dart handler is invoked; it fails open on any issue and exits 0.
+      final r = await runScript('pub-add', pubAddInput('flutter pub add http'));
+      expect(r.exitCode, 0);
+    });
+  });
+
+  group('deps_check.sh --mode=pubspec-guard', () {
+    test(
+      'filtered: edit to a non-pubspec file exits immediately with no output',
+      () async {
+        final r = await runScript(
+          'pubspec-guard',
+          editInput('/app/lib/main.dart'),
+        );
+        expect(r.exitCode, 0);
+        expect(r.stdout, isEmpty);
+      },
+    );
+
+    test(
+      'pass-through: edit to pubspec.yaml reaches Dart and exits 0',
+      () async {
+        final r = await runScript(
+          'pubspec-guard',
+          editInput('/app/pubspec.yaml'),
+        );
+        expect(r.exitCode, 0);
+      },
+    );
+  });
+}

--- a/test/scripts/inspector_mcp_sh_test.dart
+++ b/test/scripts/inspector_mcp_sh_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'support.dart';
+
+void main() {
+  final scriptsDir = path.join(Directory.current.path, 'scripts');
+
+  group('inspector_mcp.sh', () {
+    test('starts and lists expected tools', () async {
+      final process = await Process.start('bash', [
+        path.join(scriptsDir, 'inspector_mcp.sh'),
+      ]);
+      addTearDown(process.kill);
+
+      final tools = await listMcpTools(
+        process,
+      ).timeout(const Duration(seconds: 30));
+
+      expect(
+        tools,
+        containsAll([
+          'run_app',
+          'reload',
+          'get_output',
+          'take_screenshot',
+          'inspect_layout',
+          'evaluate',
+          'get_route',
+          'navigate',
+          'perform_tap',
+          'perform_set_text',
+          'perform_scroll',
+          'get_semantics',
+          'close_app',
+        ]),
+      );
+    });
+  });
+}

--- a/test/scripts/packages_mcp_sh_test.dart
+++ b/test/scripts/packages_mcp_sh_test.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'support.dart';
+
+void main() {
+  final scriptsDir = path.join(Directory.current.path, 'scripts');
+
+  group('packages_mcp.sh', () {
+    test('starts and lists expected tools', () async {
+      final process = await Process.start('bash', [
+        path.join(scriptsDir, 'packages_mcp.sh'),
+      ]);
+      addTearDown(process.kill);
+
+      final tools = await listMcpTools(
+        process,
+      ).timeout(const Duration(seconds: 30));
+
+      expect(
+        tools,
+        containsAll(['package_summary', 'library_stub', 'class_stub']),
+      );
+    });
+  });
+}

--- a/test/scripts/support.dart
+++ b/test/scripts/support.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Sends the MCP initialize handshake to [process], then calls tools/list and
+/// returns the tool names. Kills the process when done.
+Future<List<String>> listMcpTools(Process process) async {
+  final iter = StreamIterator(
+    process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+  );
+
+  // Reads the next non-empty, non-notification line (i.e. a response).
+  Future<Map<String, dynamic>> nextResponse(int id) async {
+    while (await iter.moveNext()) {
+      final line = iter.current.trim();
+      if (line.isEmpty) continue;
+      final msg = jsonDecode(line) as Map<String, dynamic>;
+      // Skip server-initiated notifications (no 'id' field).
+      if (msg.containsKey('id') && msg['id'] == id) return msg;
+    }
+    throw StateError('Stream ended before response id=$id');
+  }
+
+  void send(Map<String, dynamic> msg) => process.stdin.writeln(jsonEncode(msg));
+
+  // initialize
+  send({
+    'jsonrpc': '2.0',
+    'id': 1,
+    'method': 'initialize',
+    'params': {
+      'protocolVersion': '2024-11-05',
+      'capabilities': {},
+      'clientInfo': {'name': 'smoke-test', 'version': '0.0.1'},
+    },
+  });
+  await nextResponse(1);
+
+  // notifications/initialized
+  send({'jsonrpc': '2.0', 'method': 'notifications/initialized', 'params': {}});
+
+  // tools/list
+  send({'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list', 'params': {}});
+  final toolsResponse = await nextResponse(2);
+
+  process.kill();
+  await iter.cancel();
+
+  final tools = (toolsResponse['result']?['tools'] as List? ?? []).cast<Map>();
+  return tools.map((t) => t['name'] as String).toList();
+}


### PR DESCRIPTION
Improves the hooks and adds test coverage for all three shell entry points.

- Switch `bin/deps_check.dart` from manual arg parsing to `package:args`
- Add pubspec-guard fast-exit to `scripts/deps_check.sh`: skip the Dart VM when the edited file isn't `pubspec.yaml` (mirrors the existing pub-add fast-exit)
- Add `test/scripts/` with smoke tests covering:
  - `deps_check.sh`: filtered (fast-exit) and pass-through cases for both `--mode=pub-add` and `--mode=pubspec-guard`
  - `inspector_mcp.sh` and `packages_mcp.sh`: full MCP handshake + `tools/list` to verify each server starts and exposes its expected tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)