### PR TITLE
Add bump-version command to tool/repo.dart

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,13 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Live Flutter app introspection for coding agents: screenshots, widget-tree inspection, tap/type/scroll, and error capture. Dart package API summarization for agents.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",
-  "keywords": ["dart", "flutter"],
+  "keywords": [
+    "dart",
+    "flutter"
+  ],
   "mcpServers": {
     "inspector": {
       "command": "${CLAUDE_PLUGIN_ROOT}/scripts/inspector_mcp.sh",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr edit "${{ github.event.pull_request.number }}" \
-            --add-label "release-pr" || true  # label may not exist yet; fail open
+            --add-label "release-pr" || true  # fail open
 
       - name: Comment on PR about release
         if:
@@ -68,9 +68,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.current }}"
+          NOTES=$(dart run tool/repo.dart extract-changelog "$VERSION")
           gh pr comment "${{ github.event.pull_request.number }}" \
             --edit-last --create-if-none \
-            --body "🚀 **Note:** merging this PR will publish version 'v${VERSION}'."
+            --body "Note: merging this PR will create a new release.\n\n" \
+              "### ${VERSION}\n\n${NOTES}"
 
       # --- Push-to-main steps ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.current }}"
           NOTES=$(dart run tool/repo.dart extract-changelog "$VERSION")
+          echo -e "Note: merging this PR will create a new release.\n\n### ${VERSION}\n\n${NOTES}" > comment.txt
           gh pr comment "${{ github.event.pull_request.number }}" \
             --edit-last --create-if-none \
-            --body "Note: merging this PR will create a new release.\n\n### ${VERSION}\n\n${NOTES}"
+            --body-file comment.txt
 
       # --- Push-to-main steps ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           VERSION="${{ steps.version.outputs.current }}"
           gh pr comment "${{ github.event.pull_request.number }}" \
             --edit-last --create-if-none \
-            --body "🚀 **Note:** merging this PR will publish version `v${VERSION}`."
+            --body "🚀 **Note:** merging this PR will publish version 'v${VERSION}'."
 
       # --- Push-to-main steps ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,7 @@ jobs:
           NOTES=$(dart run tool/repo.dart extract-changelog "$VERSION")
           gh pr comment "${{ github.event.pull_request.number }}" \
             --edit-last --create-if-none \
-            --body "Note: merging this PR will create a new release.\n\n" \
-              "### ${VERSION}\n\n${NOTES}"
+            --body "Note: merging this PR will create a new release.\n\n### ${VERSION}\n\n${NOTES}"
 
       # --- Push-to-main steps ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.0-wip
+## 1.3.0
 
 - Fixed a race condition where app output emitted during startup was dropped;
   `run_app` now returns buffered output (build messages, initial route)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,10 +1,13 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Live Flutter app introspection for coding agents: screenshots, widget-tree inspection, tap/type/scroll, and error capture. Dart package API summarization for agents.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",
-  "keywords": ["dart", "flutter"],
+  "keywords": [
+    "dart",
+    "flutter"
+  ],
   "mcpServers": {
     "inspector": {
       "command": "${extensionPath}/scripts/inspector_mcp.sh",

--- a/tool/repo.dart
+++ b/tool/repo.dart
@@ -22,7 +22,8 @@ void main(List<String> args) async {
         ..addCommand(CheckCommand())
         ..addCommand(ValidateManifestsCommand())
         ..addCommand(GenerateDocsCommand())
-        ..addCommand(ExtractChangelogCommand());
+        ..addCommand(ExtractChangelogCommand())
+        ..addCommand(BumpVersionCommand());
 
   try {
     await runner.run(args);
@@ -209,6 +210,111 @@ class ExtractChangelogCommand extends Command<void> {
     }
 
     print(body.toString().trim());
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+class BumpVersionCommand extends Command<void> {
+  @override
+  String get name => 'bump-version';
+
+  @override
+  String get description =>
+      'Bump the release version in plugin.json, gemini-extension.json, and '
+      'CHANGELOG.md. Defaults to the current -wip version.';
+
+  @override
+  String get invocation => '${runner!.executableName} bump-version [<version>]';
+
+  @override
+  void run() {
+    final String version;
+
+    if (argResults!.rest.isEmpty) {
+      // Derive from the first changelog entry, which must end in '-wip'.
+      final errors = <String>[];
+      final entries = _readChangelogVersions('CHANGELOG.md', errors);
+      if (errors.isNotEmpty) {
+        for (final e in errors) {
+          stderr.writeln('error: $e');
+        }
+        exit(1);
+      }
+      final first = entries.first;
+      if (!first.endsWith('-wip')) {
+        stderr.writeln(
+          'error: first CHANGELOG.md entry is "$first", which does not end '
+          'in "-wip". Pass an explicit version or add a -wip section.',
+        );
+        exit(1);
+      }
+      version = first.substring(0, first.length - '-wip'.length);
+    } else {
+      version = argResults!.rest.first;
+    }
+
+    // Update both manifest files.
+    _bumpJsonVersion('.claude-plugin/plugin.json', version);
+    _bumpJsonVersion('gemini-extension.json', version);
+
+    // Rename the -wip heading in CHANGELOG.md.
+    _bumpChangelog('CHANGELOG.md', version);
+
+    // Confirm and show what will be released.
+    print('Bumped to v$version.');
+    print('');
+    print(
+      'Merging a PR with these changes will trigger a release of v$version.',
+    );
+    print('');
+    print('Changelog for v$version:');
+    print('');
+
+    // Re-use extract logic: find and print the section.
+    final lines = File('CHANGELOG.md').readAsLinesSync();
+    final start = lines.indexWhere((l) => l.trim() == '## $version');
+    final body = StringBuffer();
+    for (var i = start + 1; i < lines.length; i++) {
+      if (lines[i].startsWith('## ')) break;
+      body.writeln(lines[i]);
+    }
+    print(body.toString().trim());
+  }
+
+  void _bumpJsonVersion(String filePath, String version) {
+    final file = File(filePath);
+    final Map<String, dynamic> json;
+    try {
+      json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    } on FormatException catch (e) {
+      stderr.writeln('error: $filePath: invalid JSON — $e');
+      exit(1);
+    }
+    json['version'] = version;
+    // Preserve a trailing newline.
+    file.writeAsStringSync(
+      '${const JsonEncoder.withIndent('  ').convert(json)}\n',
+    );
+    print('  updated $filePath');
+  }
+
+  void _bumpChangelog(String filePath, String version) {
+    final file = File(filePath);
+    final original = file.readAsStringSync();
+    // Replace the first occurrence of a -wip heading with the release version.
+    final updated = original.replaceFirst(
+      RegExp(r'^## .+-wip$', multiLine: true),
+      '## $version',
+    );
+    if (updated == original) {
+      stderr.writeln(
+        'warning: no -wip heading found in $filePath; changelog not updated',
+      );
+      return;
+    }
+    file.writeAsStringSync(updated);
+    print('  updated $filePath');
   }
 }
 

--- a/tool/repo.dart
+++ b/tool/repo.dart
@@ -264,10 +264,6 @@ class BumpVersionCommand extends Command<void> {
     // Confirm and show what will be released.
     print('Bumped to v$version.');
     print('');
-    print(
-      'Merging a PR with these changes will trigger a release of v$version.',
-    );
-    print('');
     print('Changelog for v$version:');
     print('');
 
@@ -280,6 +276,10 @@ class BumpVersionCommand extends Command<void> {
       body.writeln(lines[i]);
     }
     print(body.toString().trim());
+    print('');
+    print(
+      'Note that merging a PR with these changes will trigger a release of v$version.',
+    );
   }
 
   void _bumpJsonVersion(String filePath, String version) {


### PR DESCRIPTION
Adds a `bump-version` command to `tool/repo.dart` to streamline release preparation.

- With no argument, reads the first CHANGELOG.md entry, fails if it doesn't end in `-wip`, and uses the stripped version
- With an explicit version argument, uses that directly
- Updates `plugin.json`, `gemini-extension.json`, and renames the `-wip` heading in `CHANGELOG.md`
- Prints a reminder that merging will trigger a release, followed by the changelog section for the bumped version