### PR TITLE
disable hooks for gemini-cli; prep to publish 1.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Live Flutter app introspection for coding agents: screenshots, widget-tree inspection, tap/type/scroll, and error capture. Dart package API summarization for agents.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.1
+
+- Disabled Gemini `BeforeTool` hooks for now: Claude Code rejects unknown keys
+  in `hooks/hooks.json` at startup, and there is no way to declare hooks inside
+  `gemini-extension.json` yet. Tracking in
+  [gemini-cli#25630](https://github.com/google-gemini/gemini-cli/issues/25630).
+
 ## 1.3.0
 
 - Fixed a race condition where app output emitted during startup was dropped;

--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 # Flutter Slipstream
 
-Flutter Slipstream makes AI coding agents significantly more effective on Dart
-and Flutter projects. It works as a plugin for
-[Claude Code](https://claude.ai/code) and as an extension for
-[Gemini CLI](https://github.com/google-gemini/gemini-cli). It addresses two
-structural problems agents face: a training cutoff that leads to stale package
-choices and subtly wrong API signatures, and a lack of runtime visibility into a
-running Flutter app — agents can't see screenshots, inspect the widget tree, or
-verify that a state change took effect.
+Flutter Slipstream makes AI coding agents more effective on Dart and Flutter
+projects. It works as a plugin for [Claude Code](https://claude.ai/code) and as
+an extension for [Gemini CLI](https://github.com/google-gemini/gemini-cli). It
+addresses two structural problems agents face: a training cutoff that leads to
+stale package choices and subtly wrong API signatures, and a lack of runtime
+visibility into a running Flutter app — agents can't see screenshots, inspect
+the widget tree, or verify that a state change took effect.
 
 ## Features
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Live Flutter app introspection for coding agents: screenshots, widget-tree inspection, tap/type/scroll, and error capture. Dart package API summarization for agents.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/hooks/hooks-gemini.json
+++ b/hooks/hooks-gemini.json
@@ -1,5 +1,4 @@
 {
-  "_hooksComment": "Note that BeforeTool is a Gemini specific hook.",
   "hooks": {
     "BeforeTool": [
       {

--- a/tool/repo.dart
+++ b/tool/repo.dart
@@ -119,8 +119,8 @@ class ValidateManifestsCommand extends Command<void> {
   void run() {
     var failed = false;
 
-    // hooks/hooks.json — valid JSON, no required keys.
-    failed |= _validateJson('hooks/hooks.json', const []);
+    // hooks/hooks-gemini.json — valid JSON, no required keys.
+    failed |= _validateJson('hooks/hooks-gemini.json', const []);
 
     // .claude-plugin/plugin.json and gemini-extension.json — full key check.
     failed |= _validateJson('.claude-plugin/plugin.json', _manifestKeys);


### PR DESCRIPTION
- disable hooks for gemini-cli
- rev to 1.3.1

Disabled Gemini `BeforeTool` hooks for now: Claude Code rejects unknown keys in `hooks/hooks.json` at startup, and there is no way to declare hooks inside `gemini-extension.json` yet. Tracking in https://github.com/google-gemini/gemini-cli/issues/25630.