### PR TITLE
Update slipstream_agent to v1.4.0 with error handling improvements

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Live Flutter app introspection for coding agents: screenshots, widget-tree inspection, tap/type/scroll, and error capture. Dart package API summarization for agents.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.0-wip
+## 1.4.0
 
 - Updated for `package:slipstream_agent` 1.2.0:
   - `get_output` now calls `ext.slipstream.clear_errors` after draining output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.4.0-wip
+
+- Updated for `package:slipstream_agent` 1.2.0:
+  - `get_output` now calls `ext.slipstream.clear_errors` after draining output
+    that contains `[flutter.error]` lines, dismissing the error banner once the
+    agent has acknowledged the errors.
+  - Added `byTextContaining` finder support to `perform_tap`, `perform_set_text`,
+    `perform_scroll`, and `perform_scroll_until_visible`. Matches any `Text`
+    widget whose content contains the given value as a substring — useful when
+    displayed text is truncated (e.g. `"Lorem ipsum..."` vs the full string).
+  - `take_screenshot` tool description now explains the `flutter.error: <msg>`
+    chip that appears when a Flutter framework error has been caught, and directs
+    the agent to call `get_output` to read the full error.
+
 ## 1.3.1
 
 - Disabled Gemini `BeforeTool` hooks for now: Claude Code rejects unknown keys

--- a/docs/slipstream_doc.md
+++ b/docs/slipstream_doc.md
@@ -178,10 +178,17 @@ take_screenshot([pixel_ratio])
 
 Captures a PNG screenshot of the running Flutter app. Use proactively after a
 reload to visually confirm UI changes are correct, and when diagnosing layout or
-rendering issues. Root widget bounds are resolved automatically. Note: only the
-Flutter view is captured — native system UI such as platform share sheets,
-permission dialogs, or OS-level overlays will not appear in the screenshot even
-if visible on screen.
+rendering issues. Root widget bounds are resolved automatically.
+
+Note: only the Flutter view is captured — native system UI such as platform
+share sheets, permission dialogs, or OS-level overlays will not appear in the
+screenshot even if visible on screen.
+
+If a red chip reading "flutter.error: <msg>" is visible near the top of the
+screenshot, a Flutter framework error has been caught by the app. Call
+get_output to read the full error (which includes a widget ID for
+inspect_layout), then address the root cause. The banner clears automatically
+after get_output acknowledges the errors.
 
 - `pixel_ratio`: Device pixel ratio for the screenshot. Higher values produce
   sharper images. Defaults to 1.0.
@@ -267,14 +274,14 @@ widget's center — triggers GestureDetector.onTap, InkWell.onTap, and any other
 gesture recognizers.
 
 Finders: byKey (ValueKey string), byType (widget type name, e.g.
-"ElevatedButton"), byText (Text widget content), bySemanticsLabel (Semantics
-widget label).
+"ElevatedButton"), byText (exact Text content), byTextContaining (Text content
+substring), bySemanticsLabel (Semantics widget label).
 
 Requires the slipstream_agent companion package. Without it, use
 perform_semantic_action with action "tap" instead.
 
-- `finder`: (required) How to find the widget: "byKey", "byType", "byText", or
-  "bySemanticsLabel".
+- `finder`: (required) How to find the widget: "byKey", "byType", "byText",
+  "byTextContaining", or "bySemanticsLabel".
 - `finder_value`: (required) The value to match against the chosen finder.
 
 ### `inspector:perform_set_text`
@@ -289,7 +296,8 @@ TextInputFormatters are not applied since text is set directly without going
 through the input pipeline.
 
 Finders: byKey (ValueKey string), byType (widget type name, e.g. "TextField"),
-byText (Text widget content), bySemanticsLabel (Semantics widget label).
+byText (exact Text content), byTextContaining (Text content substring),
+bySemanticsLabel (Semantics widget label).
 
 Tip: call perform_tap on the field first if the app requires focus before
 accepting text input.
@@ -297,8 +305,8 @@ accepting text input.
 Requires the slipstream_agent companion package. Without it, use
 perform_semantic_action with action "setText" instead.
 
-- `finder`: (required) How to find the widget: "byKey", "byType", "byText", or
-  "bySemanticsLabel".
+- `finder`: (required) How to find the widget: "byKey", "byType", "byText",
+  "byTextContaining", or "bySemanticsLabel".
 - `finder_value`: (required) The value to match against the chosen finder.
 - `text`: (required) The text to set. Replaces the field's current content.
 
@@ -313,14 +321,15 @@ locates the Scrollable (e.g. ListView, SingleChildScrollView) directly. Clamped
 to the scroll extent bounds.
 
 Finders: byKey (ValueKey string), byType (widget type name, e.g. "ListView"),
-byText (Text widget content), bySemanticsLabel (Semantics widget label).
+byText (Text widget content), byTextContaining (Text content substring),
+bySemanticsLabel (Semantics widget label).
 
 To bring a specific widget into view, use perform_scroll_until_visible instead.
 
 Requires the slipstream_agent companion package.
 
 - `finder`: (required) How to find the Scrollable widget: "byKey", "byType",
-  "byText", or "bySemanticsLabel".
+  "byText", "byTextContaining", or "bySemanticsLabel".
 - `finder_value`: (required) The value to match against the chosen finder.
 - `direction`: (required) Scroll direction: "up", "down", "left", or "right".
 - `pixels`: (required) Number of logical pixels to scroll.
@@ -336,7 +345,8 @@ Two finders are required: one to locate the target widget, and one to locate the
 Scrollable that contains it.
 
 Finders for both: byKey (ValueKey string), byType (widget type name), byText
-(Text widget content), bySemanticsLabel (Semantics label).
+(exact Text content), byTextContaining (Text content substring),
+bySemanticsLabel (Semantics label).
 
 Example: scroll a ListView (scroll_finder="byType",
 scroll_finder_value="ListView") until item_42 is visible (finder="byKey",
@@ -345,10 +355,10 @@ finder_value="item_42").
 Requires the slipstream_agent companion package.
 
 - `finder`: (required) How to find the target widget: "byKey", "byType",
-  "byText", or "bySemanticsLabel".
+  "byText", "byTextContaining", or "bySemanticsLabel".
 - `finder_value`: (required) The value to match against the target finder.
 - `scroll_finder`: (required) How to find the Scrollable: "byKey", "byType",
-  "byText", or "bySemanticsLabel".
+  "byText", "byTextContaining", or "bySemanticsLabel".
 - `scroll_finder_value`: (required) The value to match against the scroll
   finder.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter-slipstream",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Live Flutter app introspection for coding agents: screenshots, widget-tree inspection, tap/type/scroll, and error capture. Dart package API summarization for agents.",
   "repository": "https://github.com/devoncarew/flutter-slipstream",
   "license": "BSD-3-Clause license",

--- a/lib/src/inspector/flutter_service_extensions.dart
+++ b/lib/src/inspector/flutter_service_extensions.dart
@@ -228,6 +228,20 @@ class FlutterServiceExtensions {
     }
   }
 
+  /// Calls `ext.slipstream.clear_errors` to dismiss the persistent
+  /// `flutter.error` banner from the ghost overlay.
+  ///
+  /// Call after draining output that contained `[flutter.error]` lines, or
+  /// whenever the agent has acknowledged the errors. Best-effort: failures are
+  /// silently ignored.
+  Future<void> slipstreamClearErrors() async {
+    try {
+      await _callExtension('ext.slipstream.clear_errors');
+    } catch (_) {
+      // Best-effort — don't let a clear-errors failure break the calling tool.
+    }
+  }
+
   /// Calls `ext.slipstream.overlays` to show or hide Slipstream-managed
   /// overlays (currently the Flutter debug banner).
   ///

--- a/lib/src/inspector/tools/get_output_tool.dart
+++ b/lib/src/inspector/tools/get_output_tool.dart
@@ -40,10 +40,10 @@ class GetOutputTool extends InspectorTool {
 
       // "get output: 7 lines, 1 error"
       var msg = '∅';
+      final errors =
+          lines.where((line) => line.startsWith('[flutter.error]')).length;
       if (lines.isNotEmpty) {
         msg = lines.length == 1 ? '1 line' : '${lines.length} lines';
-        final errors =
-            lines.where((line) => line.startsWith('[flutter.error]')).length;
         if (errors != 0) {
           final errDesc = errors == 1 ? '1 error' : '$errors errors';
           msg = '$msg, $errDesc';
@@ -51,6 +51,11 @@ class GetOutputTool extends InspectorTool {
       }
 
       extensions.slipstreamLog('get output', kind: 'read', details: msg);
+
+      // Clear the error banner once the agent has seen the errors.
+      if (errors > 0) {
+        extensions.slipstreamClearErrors();
+      }
     }
 
     return CallToolResult(content: [TextContent(text: text)]);

--- a/lib/src/inspector/tools/perform_scroll_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_tool.dart
@@ -4,11 +4,6 @@ import 'package:vm_service/vm_service.dart' show RPCError;
 import '../../utils.dart';
 import '../tool_context.dart';
 
-const _finderDescription =
-    'How to find the Scrollable widget: "byKey", "byType", "byText", or '
-    '"bySemanticsLabel".';
-const _finderValueDescription = 'The value to match against the chosen finder.';
-
 /// Implements the `perform_scroll` MCP tool.
 ///
 /// Scrolls a Scrollable widget by a fixed number of pixels. Requires the
@@ -17,20 +12,28 @@ class PerformScrollTool extends InspectorTool {
   @override
   final Tool definition = Tool(
     name: 'perform_scroll',
-    description:
-        'Scrolls a Scrollable widget by a fixed number of logical pixels. '
-        'The finder locates the Scrollable (e.g. ListView, SingleChildScrollView) '
-        'directly. Clamped to the scroll extent bounds.\n\n'
-        'Finders: byKey (ValueKey string), byType (widget type name, e.g. '
-        '"ListView"), byText (Text widget content), bySemanticsLabel '
-        '(Semantics widget label).\n\n'
-        'To bring a specific widget into view, use perform_scroll_until_visible '
-        'instead.\n\n'
-        'Requires the slipstream_agent companion package.',
+    description: '''
+Scrolls a Scrollable widget by a fixed number of logical pixels. The finder
+locates the Scrollable (e.g. ListView, SingleChildScrollView) directly. Clamped
+to the scroll extent bounds.
+
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "ListView"),
+byText (Text widget content), byTextContaining (Text content substring),
+bySemanticsLabel (Semantics widget label).
+
+To bring a specific widget into view, use perform_scroll_until_visible instead.
+
+Requires the slipstream_agent companion package.''',
     inputSchema: Schema.object(
       properties: {
-        'finder': Schema.string(description: _finderDescription),
-        'finder_value': Schema.string(description: _finderValueDescription),
+        'finder': Schema.string(
+          description:
+              'How to find the Scrollable widget: "byKey", "byType", "byText", '
+              '"byTextContaining", or "bySemanticsLabel".',
+        ),
+        'finder_value': Schema.string(
+          description: 'The value to match against the chosen finder.',
+        ),
         'direction': Schema.string(
           description: 'Scroll direction: "up", "down", "left", or "right".',
         ),

--- a/lib/src/inspector/tools/perform_scroll_until_visible_tool.dart
+++ b/lib/src/inspector/tools/perform_scroll_until_visible_tool.dart
@@ -11,30 +11,34 @@ class PerformScrollUntilVisibleTool extends InspectorTool {
   @override
   final Tool definition = Tool(
     name: 'perform_scroll_until_visible',
-    description:
-        'Scrolls a Scrollable widget until a target widget is visible in the '
-        'viewport. Two finders are required: one to locate the target widget, '
-        'and one to locate the Scrollable that contains it.\n\n'
-        'Finders for both: byKey (ValueKey string), byType (widget type name), '
-        'byText (Text widget content), bySemanticsLabel (Semantics label).\n\n'
-        'Example: scroll a ListView (scroll_finder="byType", '
-        'scroll_finder_value="ListView") until item_42 is visible '
-        '(finder="byKey", finder_value="item_42").\n\n'
-        'Requires the slipstream_agent companion package.',
+    description: '''
+Scrolls a Scrollable widget until a target widget is visible in the viewport.
+Two finders are required: one to locate the target widget, and one to locate
+the Scrollable that contains it.
+
+Finders for both: byKey (ValueKey string), byType (widget type name), byText
+(exact Text content), byTextContaining (Text content substring),
+bySemanticsLabel (Semantics label).
+
+Example: scroll a ListView (scroll_finder="byType",
+scroll_finder_value="ListView") until item_42 is visible (finder="byKey",
+finder_value="item_42").
+
+Requires the slipstream_agent companion package.''',
     inputSchema: Schema.object(
       properties: {
         'finder': Schema.string(
           description:
-              'How to find the target widget: "byKey", "byType", "byText", or '
-              '"bySemanticsLabel".',
+              'How to find the target widget: "byKey", "byType", "byText", '
+              '"byTextContaining", or "bySemanticsLabel".',
         ),
         'finder_value': Schema.string(
           description: 'The value to match against the target finder.',
         ),
         'scroll_finder': Schema.string(
           description:
-              'How to find the Scrollable: "byKey", "byType", "byText", or '
-              '"bySemanticsLabel".',
+              'How to find the Scrollable: "byKey", "byType", "byText", '
+              '"byTextContaining", or "bySemanticsLabel".',
         ),
         'scroll_finder_value': Schema.string(
           description: 'The value to match against the scroll finder.',

--- a/lib/src/inspector/tools/perform_set_text_tool.dart
+++ b/lib/src/inspector/tools/perform_set_text_tool.dart
@@ -3,11 +3,6 @@ import 'package:vm_service/vm_service.dart' show RPCError;
 
 import '../tool_context.dart';
 
-const _finderDescription =
-    'How to find the widget: "byKey", "byType", "byText", or '
-    '"bySemanticsLabel".';
-const _finderValueDescription = 'The value to match against the chosen finder.';
-
 /// Implements the `perform_set_text` MCP tool.
 ///
 /// Sets the text content of a text field located by a finder. Requires the
@@ -17,22 +12,31 @@ class PerformSetTextTool extends InspectorTool {
   @override
   final Tool definition = Tool(
     name: 'perform_set_text',
-    description:
-        'Sets the text content of a text field located by a finder. Replaces '
-        'the field\'s current content and fires the field\'s onChanged '
-        'callback. Note: TextInputFormatters are not applied since text is set '
-        'directly without going through the input pipeline.\n\n'
-        'Finders: byKey (ValueKey string), byType (widget type name, e.g. '
-        '"TextField"), byText (Text widget content), bySemanticsLabel '
-        '(Semantics widget label).\n\n'
-        'Tip: call perform_tap on the field first if the app requires focus '
-        'before accepting text input.\n\n'
-        'Requires the slipstream_agent companion package. Without it, use '
-        'perform_semantic_action with action "setText" instead.',
+    description: '''
+Sets the text content of a text field located by a finder. Replaces the field's
+current content and fires the field's onChanged callback. Note:
+TextInputFormatters are not applied since text is set directly without going
+through the input pipeline.
+
+Finders: byKey (ValueKey string), byType (widget type name, e.g. "TextField"),
+byText (exact Text content), byTextContaining (Text content substring),
+bySemanticsLabel (Semantics widget label).
+
+Tip: call perform_tap on the field first if the app requires focus before
+accepting text input.
+
+Requires the slipstream_agent companion package. Without it, use
+perform_semantic_action with action "setText" instead.''',
     inputSchema: Schema.object(
       properties: {
-        'finder': Schema.string(description: _finderDescription),
-        'finder_value': Schema.string(description: _finderValueDescription),
+        'finder': Schema.string(
+          description:
+              'How to find the widget: "byKey", "byType", "byText", "byTextContaining", '
+              'or "bySemanticsLabel".',
+        ),
+        'finder_value': Schema.string(
+          description: 'The value to match against the chosen finder.',
+        ),
         'text': Schema.string(
           description:
               'The text to set. Replaces the field\'s current content.',

--- a/lib/src/inspector/tools/perform_tap_tool.dart
+++ b/lib/src/inspector/tools/perform_tap_tool.dart
@@ -3,11 +3,6 @@ import 'package:vm_service/vm_service.dart' show RPCError;
 
 import '../tool_context.dart';
 
-const _finderDescription =
-    'How to find the widget: "byKey", "byType", "byText", or '
-    '"bySemanticsLabel".';
-const _finderValueDescription = 'The value to match against the chosen finder.';
-
 /// Implements the `perform_tap` MCP tool.
 ///
 /// Taps a widget located by a finder. Requires the slipstream_agent companion
@@ -17,19 +12,27 @@ class PerformTapTool extends InspectorTool {
   @override
   final Tool definition = Tool(
     name: 'perform_tap',
-    description:
-        'Taps a widget located by a finder. Synthesizes a pointer down/up '
-        'event at the widget\'s center — triggers GestureDetector.onTap, '
-        'InkWell.onTap, and any other gesture recognizers.\n\n'
-        'Finders: byKey (ValueKey string), byType (widget type name, e.g. '
-        '"ElevatedButton"), byText (Text widget content), bySemanticsLabel '
-        '(Semantics widget label).\n\n'
-        'Requires the slipstream_agent companion package. Without it, use '
-        'perform_semantic_action with action "tap" instead.',
+    description: '''
+Taps a widget located by a finder. Synthesizes a pointer down/up event at the
+widget's center — triggers GestureDetector.onTap, InkWell.onTap, and any other
+gesture recognizers.
+
+Finders: byKey (ValueKey string), byType (widget type name, e.g.
+"ElevatedButton"), byText (exact Text content), byTextContaining (Text content
+substring), bySemanticsLabel (Semantics widget label).
+
+Requires the slipstream_agent companion package. Without it, use
+perform_semantic_action with action "tap" instead.''',
     inputSchema: Schema.object(
       properties: {
-        'finder': Schema.string(description: _finderDescription),
-        'finder_value': Schema.string(description: _finderValueDescription),
+        'finder': Schema.string(
+          description:
+              'How to find the widget: "byKey", "byType", "byText", "byTextContaining", '
+              'or "bySemanticsLabel".',
+        ),
+        'finder_value': Schema.string(
+          description: 'The value to match against the chosen finder.',
+        ),
       },
       required: ['finder', 'finder_value'],
     ),

--- a/lib/src/inspector/tools/take_screenshot_tool.dart
+++ b/lib/src/inspector/tools/take_screenshot_tool.dart
@@ -11,14 +11,20 @@ class TakeScreenshotTool extends InspectorTool {
   @override
   final Tool definition = Tool(
     name: 'take_screenshot',
-    description:
-        'Captures a PNG screenshot of the running Flutter app. Use '
-        'proactively after a reload to visually confirm UI changes are '
-        'correct, and when diagnosing layout or rendering issues. '
-        'Root widget bounds are resolved automatically. '
-        'Note: only the Flutter view is captured — native system UI such as '
-        'platform share sheets, permission dialogs, or OS-level overlays will '
-        'not appear in the screenshot even if visible on screen.',
+    description: '''
+Captures a PNG screenshot of the running Flutter app. Use proactively after a
+reload to visually confirm UI changes are correct, and when diagnosing layout
+or rendering issues.  Root widget bounds are resolved automatically. 
+
+Note: only the Flutter view is captured — native system UI such as platform
+share sheets, permission dialogs, or OS-level overlays will not appear in the
+screenshot even if visible on screen.
+
+If a red chip reading "flutter.error: <msg>" is visible near the top of the
+screenshot, a Flutter framework error has been caught by the app. Call
+get_output to read the full error (which includes a widget ID for
+inspect_layout), then address the root cause. The banner clears automatically
+after get_output acknowledges the errors.''',
     inputSchema: Schema.object(
       properties: {
         'pixel_ratio': Schema.num(

--- a/test/integration/inspector_script.dart
+++ b/test/integration/inspector_script.dart
@@ -38,9 +38,9 @@ void main(List<String> args) {
     await _startApp(env, projectDir);
   });
 
-  // Wait for 1 second after every test.
+  // Wait a brief period of time between tests.
   tearDown(() async {
-    await Future.delayed(Duration(milliseconds: 500));
+    await Future.delayed(Duration(milliseconds: 300));
   });
 
   // Tear down after all the tests.
@@ -207,8 +207,6 @@ void main(List<String> args) {
         await env.serverConnection.callTool(
           CallToolRequest(name: 'navigate', arguments: {'path': '/widgets'}),
         );
-
-        await smallDelay;
 
         final result = await env.serverConnection.callTool(
           CallToolRequest(name: 'get_route', arguments: {}),
@@ -434,7 +432,6 @@ void main(List<String> args) {
         await env.serverConnection.callTool(
           CallToolRequest(name: 'navigate', arguments: {'path': '/discover'}),
         );
-        await smallDelay;
 
         final result = await env.serverConnection.callTool(
           CallToolRequest(


### PR DESCRIPTION
Update for `package:slipstream_agent` 1.2.0 and prep for a v1.4.0 release:

- `get_output` now calls `ext.slipstream.clear_errors` after draining output
    that contains `[flutter.error]` lines, dismissing the error banner once the
    agent has acknowledged the errors.
- Added `byTextContaining` finder support to `perform_tap`, `perform_set_text`,
    `perform_scroll`, and `perform_scroll_until_visible`. Matches any `Text`
    widget whose content contains the given value as a substring — useful when
    displayed text is truncated (e.g. `"Lorem ipsum..."` vs the full string).
- `take_screenshot` tool description now explains the `flutter.error: <msg>`
    chip that appears when a Flutter framework error has been caught, and directs
    the agent to call `get_output` to read the full error.