### PR TITLE
add 'slipstream-packages' skill; renamed main skill to 'slipstream-inspector'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,20 @@
 ## 1.5.1-wip
 
-- Remove the Bash MCP entrypoint scripts in favor of calling the Dart MCP
-  entrypoints directly.
-- Replace the per-agent package validation hooks with a single `add-package`
+- Replaced the per-agent package validation hooks with a single `add-package`
   skill. The skill fires when an agent is about to add a Dart or Flutter package
   and instructs it to read `flutter pub add` output for discontinued-package and
   outdated-version warnings. Equivalent guidance is embedded in the Gemini CLI
   context file. This eliminates the per-agent hook infrastructure (different
   event names, field shapes, and invocation styles across Claude Code, Gemini
   CLI, and GitHub Copilot) and the external pub.dev network calls at hook time.
+- Added a `slipstream-packages` skill that instructs the agent to use the
+  packages MCP tools when writing code against an unfamiliar pub package or one
+  whose version may be newer than its training data.
+- Renamed the 'flutter-slipstream' skill to 'slipstream-inspector'.
 - Updated the privacy policy to note that we no longer make calls to
   https://pub.dev for package metadata.
+- Removed the Bash MCP entrypoint scripts in favor of calling the Dart MCP
+  entrypoints directly.
 
 ## 1.5.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,15 +48,20 @@ to read it.
 
 ## Agent Guidance
 
-- [../skills/flutter-slipstream/SKILL.md](../skills/flutter-slipstream/SKILL.md)
-  — Shipped user-facing skill: when to use `run_app` vs. terminal commands,
-  recommended workflows, and non-obvious gotchas for agents using the plugin
-  tools. Read when improving guidance shipped to end-user agents.
-
 - [../skills/add-package/SKILL.md](../skills/add-package/SKILL.md) — Shipped
   skill for safely adding Dart/Flutter package dependencies: preferred `pub add`
   workflow, reading pub output for discontinued-package and outdated-version
   warnings, and corrective actions for each. Read when improving this guidance.
+
+- [../skills/slipstream-inspector/SKILL.md](../skills/slipstream-inspector/SKILL.md)
+  — Shipped skill: when to use `run_app` vs. terminal commands, recommended
+  workflows, and non-obvious gotchas for agents using the inspector tools. Read
+  when improving guidance shipped to end-user agents.
+
+- [../skills/slipstream-packages/SKILL.md](../skills/slipstream-packages/SKILL.md)
+  — Shipped skill that instructs agents to use the packages MCP tools when
+  writing code against an unfamiliar package or one that may be newer than
+  training data. Read when improving this guidance.
 
 ## Other
 

--- a/skills/add-package/SKILL.md
+++ b/skills/add-package/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: add-package
-description: >
-  Safe workflow for adding a Dart or Flutter package dependency. Covers how to
-  read pub command output for discontinued and outdated-version warnings, and
-  what corrective action to take for each.
+description: >-
+  This skill should be used when about to add a Dart or Flutter package
+  dependency — running flutter pub add, dart pub add, or editing pubspec.yaml to
+  introduce a new package. Also load when choosing a specific version constraint
+  for a new package. Skip for upgrading existing packages (pub upgrade),
+  removing packages, or pub commands that don't introduce a new dependency.
 user-invocable: false
-trigger: >
-  TRIGGER when: about to add a Dart or Flutter package dependency — running
-  flutter pub add, dart pub add, or editing pubspec.yaml to add a new package.
-  Also trigger when choosing a specific version constraint for a package. SKIP:
-  upgrading existing packages (pub upgrade), removing packages, or pub commands
-  that don't introduce a new dependency.
 ---
 
 # Adding a Dart/Flutter Package Dependency

--- a/skills/slipstream-inspector/SKILL.md
+++ b/skills/slipstream-inspector/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: flutter-slipstream
+name: slipstream-inspector
 description: >-
   This skill should be used when the user asks to "run the Flutter app",
   "flutter run", "start the app", "launch the app", "test the UI", "take a
@@ -7,6 +7,7 @@ description: >-
   any request involving launching, observing, or interacting with a running
   Flutter app. When the flutter-slipstream plugin is installed, MCP tools
   replace terminal commands for all Flutter app interaction.
+user-invocable: false
 ---
 
 # flutter-slipstream
@@ -105,13 +106,3 @@ retaking.
 - Increase `subtree_depth` when the relevant widget is several levels down.
 - `evaluate` is useful for exact runtime values (`MediaQuery.of(...)`,
   controller state) that don't appear in the layout tree.
-
-## Learning a package API
-
-Use the `packages` tools before writing code that uses an unfamiliar package —
-they are faster and more accurate than reading `.pub-cache` source or relying on
-training-data summaries:
-
-1. `package_summary` — orient: version, entry-point import, exported names.
-2. `library_stub` — full public API as Dart signatures for one library.
-3. `class_stub` — single class when you know exactly what you need.

--- a/skills/slipstream-packages/SKILL.md
+++ b/skills/slipstream-packages/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: slipstream-packages
+description: >-
+  This skill should be used when about to write Dart or Flutter code that calls
+  into a pub package whose API is uncertain — the package is unfamiliar, or its
+  version in pubspec.lock may be newer than training data. Also load when
+  hitting an unexpected compile error or type mismatch on a package import. Skip
+  for code that only uses the Dart SDK (dart:*) or Flutter framework
+  (package:flutter/*), and packages already verified this session.
+user-invocable: false
+---
+
+# Dart Package API Lookup
+
+Training-data summaries for pub packages are often subtly out-of-date: incorrect
+parameter names, missing required/optional distinctions, wrong constructor
+shapes, renamed or removed APIs. The `packages` tools read directly from the
+local pub cache — exact signatures, always matches `pubspec.lock`, no network
+required.
+
+## Call sequence
+
+1. `package_summary(project_directory, package)` — always start here. Returns
+   version, entry-point import, library list, and exported name groups. Often
+   enough to confirm the right import path and top-level names.
+2. `library_stub(project_directory, package, library_uri)` — full public API for
+   one library as Dart signatures (no bodies, no private members). Use when you
+   need exact constructor shapes, named parameter names, or return types.
+3. `class_stub(project_directory, package, library_uri, class)` — single class
+   stub including inherited and mixin-contributed members. Use when you know
+   exactly which class you need.
+
+`project_directory` is the absolute path to the Dart/Flutter project (the
+directory containing `pubspec.yaml`). Run `dart pub get` first if
+`.dart_tool/package_config.json` is missing.
+
+## Limitation
+
+Constants values are not shown in stubs.

--- a/skills/slipstream-packages/SKILL.md
+++ b/skills/slipstream-packages/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   into a pub package whose API is uncertain — the package is unfamiliar, or its
   version in pubspec.lock may be newer than training data. Also load when
   hitting an unexpected compile error or type mismatch on a package import. Skip
-  for code that only uses the Dart SDK (dart:*) or Flutter framework
-  (package:flutter/*), and packages already verified this session.
+  for code that only uses the Dart SDK (dart:*) and packages already verified
+  this session.
 user-invocable: false
 ---
 


### PR DESCRIPTION
- Added a `slipstream-packages` skill that instructs the agent to use the packages MCP tools when writing code against an unfamiliar pub package or one whose version may be newer than its training data.
- Renamed the 'flutter-slipstream' skill to 'slipstream-inspector'.
